### PR TITLE
 Fix Group Chats sender name display error

### DIFF
--- a/src/event-handlers.js
+++ b/src/event-handlers.js
@@ -65,8 +65,8 @@ const eventHandlers = {
           this.getThreadById(message.senderID, true).then((threadSender) => {
             sender = `(${thread.name}) ${threadSender.name}` // Get true sender name from list
             log(`${this.lastThread !== message.threadID ? "\n" : ""}${sender} - ${messageBody}`, thread.color)
-          }).catch({
-            sender = thread.name // Sender not in list, keep origin
+          }).catch(function () {
+            sender = `(${thread.name}) ${sender.name}` // Sender not in list, keep origin
             log(`${this.lastThread !== message.threadID ? "\n" : ""}${sender} - ${messageBody}`, thread.color)
           })
         } else {

--- a/src/event-handlers.js
+++ b/src/event-handlers.js
@@ -93,9 +93,7 @@ const eventHandlers = {
 
         switch (ev.logMessageType) {
           case "log:thread-color":
-            Object.assign(thread, {
-              color: `#${ev.logMessageData.theme_color.slice(2)}`
-            })
+            Object.assign(thread, { color: `#${ev.logMessageData.theme_color.slice(2)}` })
             logMessage = ev.logMessageBody
             break
           default:


### PR DESCRIPTION
It showed the name which same as thread name before fixing. e.g., #63
`(Thread Name) Thread Name - some message.`
But not:
`(Thread Name) Sender Name - some message.`
