### PR TITLE
Add Messen

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,17 +1,14 @@
 {
-    "env": {
-        "node": true,
-        "mocha": true
-    },
-    "extends": "airbnb-base",
-    "rules": {
-        "quotes": [
-            "error",
-            "double"
-        ],
-        "semi": [
-            "error",
-            "never"
-        ]
-    }
+  "env": {
+    "node": true,
+    "mocha": true
+  },
+  "extends": "airbnb-base",
+  "rules": {
+    "implicit-arrow-linebreak": 0,
+    "arrow-parens": 0,
+    "function-paren-newline": 0,
+    "operator-linebreak": 0,
+    "import/no-extraneous-dependencies": 0
+  }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
     "implicit-arrow-linebreak": 0,
     "arrow-parens": 0,
     "function-paren-newline": 0,
-    "operator-linebreak": 0
+    "operator-linebreak": 0,
+    "quotes": ["error", "double", { "avoidEscape": true }]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ appstate.json
 # misc
 node_modules
 .DS_Store
-npm-debug.log*
+*debug.log*
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# Messer-specific
-tmp
-appstate.json
-
 # misc
 node_modules
 .DS_Store

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,3 @@
 {
-  "singleQuote": true,
   "trailingComma": "all"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ Command-line Messaging for Facebook Messenger
 ## Installation
 
 ```bash
-npm install -g messer
+$ npm install -g messer
 ```
 
 ## Quick Start
 
 1. Install `messer`
 2. Run `messer`
-    ```bash
-    $ messer
-    ```
+   ```bash
+   $ messer
+   ```
 3. Enter your details
 4. ...
 5. Profit
@@ -34,7 +34,7 @@ For a list of commands, jump to the [Commands Reference](https://github.com/mjka
 1. Start Messer and wait for "Enter Code" prompt
 2. Enter a 2FA code generated from your 2FA app
 
-    If at this point the login fails, go to [Facebook](https://www.facebook.com) and check for an "Unrecognised browser" notification
+   If at this point the login fails, go to [Facebook](https://www.facebook.com) and check for an "Unrecognised browser" notification
 
 3. Approve the browser/device (i.e. approve Messer)
 4. Retry from Step 1
@@ -124,8 +124,7 @@ Logs you out
 logout
 ```
 
-
-## Non-interactive Mode
+### Non-interactive Mode
 
 Messer can be run in non-interactive mode with command line arguments to execute a single command.
 
@@ -133,14 +132,20 @@ Messer can be run in non-interactive mode with command line arguments to execute
 messer --command='[command]'
 ```
 
-Login will be prompted if this is the first time logging in.  
-
+Login will be prompted if this is the first time logging in.
 
 Examples
 
 - `messer --command='m "John Smith" Hey, John'`
 - `messer --command='r Hey, John'`
 
+### Cleanup
+
+If ever you want to clean up any old Messer sessions and start from scratch, run:
+
+```bash
+$ messer cleanup
+```
 
 ## FAQ
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-const parseArgs = require('minimist');
-const Messer = require('./src/messer');
-const packageJson = require('./package.json');
+const parseArgs = require("minimist");
+const Messer = require("./src/messer");
+const packageJson = require("./package.json");
 
 const argv = parseArgs(process.argv.slice(2));
 const messer = new Messer();

--- a/index.js
+++ b/index.js
@@ -6,7 +6,9 @@ const packageJson = require("./package.json");
 const argv = parseArgs(process.argv.slice(2));
 const messer = new Messer();
 
-if (argv.command) {
+if (argv._ && argv._[0] === "cleanup") {
+  messer.logout();
+} else if (argv.command) {
   messer.startSingle(argv.command);
 } else if (argv.v) {
   console.log(packageJson.version); // eslint-disable-line

--- a/index.js
+++ b/index.js
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
-const parseArgs = require("minimist")
-const Messer = require("./src/messer")
-const packageJson = require("./package.json")
+const parseArgs = require('minimist');
+const Messer = require('./src/messer');
+const packageJson = require('./package.json');
 
-const argv = parseArgs(process.argv.slice(2))
-const messer = new Messer()
+const argv = parseArgs(process.argv.slice(2));
+const messer = new Messer();
 
 if (argv.command) {
-  messer.startSingle(argv.command)
+  messer.startSingle(argv.command);
 } else if (argv.v) {
-  console.log(packageJson.version) // eslint-disable-line
+  console.log(packageJson.version); // eslint-disable-line
 } else {
-  messer.start()
+  messer.start();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -486,6 +486,11 @@
         "domelementtype": "1"
       }
     },
+    "dotenv": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1401,10 +1406,11 @@
       }
     },
     "messen": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/messen/-/messen-0.0.4.tgz",
-      "integrity": "sha512-nhYxTFtYSenV3uvZcFnwGjQ6xcRF8JeEuWocBSFr8XIULD2odNO+1fv8TlPVn/7UGF4HPXwje6ZBIDLG2MROGw==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/messen/-/messen-0.0.5.tgz",
+      "integrity": "sha512-cgfmWM53TXe39rLFQpKUmwkeuRrOHLpEy2upfFfyRIejTi7vv8HmczKaJh2+bM1ez3gQkN1RE1Ei1wO+C2lT8g==",
       "requires": {
+        "dotenv": "^6.2.0",
         "facebook-chat-api": "github:Schmavery/facebook-chat-api#4ab4380230b58575a9cef9249bfbc1d50973f12d",
         "mkdirp": "^0.5.1",
         "prompt": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1788,6 +1788,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
+      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
+      "dev": true
+    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,9 +37,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.8.1.tgz",
-      "integrity": "sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.0.tgz",
+      "integrity": "sha512-VsK2jpqRno3Hn+at4NGtBRpR5q3OW7n5INrTKqENDNQJB99DXATQEVHlnoD1BA7Uo/qGO+ijGA/vgSAlxP9E4A==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -520,6 +520,14 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "dev": true
+        }
       }
     },
     "es-abstract": {
@@ -1135,10 +1143,9 @@
       }
     },
     "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "is-callable": {
       "version": "1.1.4",
@@ -1394,41 +1401,15 @@
       }
     },
     "messen": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/messen/-/messen-0.0.1.tgz",
-      "integrity": "sha512-lF8Ujkv8YIVqVgTdnLufZ0NarSt7Wn+9KFEOJp7dBmzfEg+0byM4/W6O6dSkv2XnG07fOGE/LKi7O9VPhMmEZw==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/messen/-/messen-0.0.3.tgz",
+      "integrity": "sha512-fwAjzN7lw4hp7AfhaGRO4EtLF7FdUYt7CzlkzVHlCdGShjlPDnfJ9gdrD+oFfiUscisqBhfCcIMBrUx0fDTjPw==",
       "requires": {
         "facebook-chat-api": "github:Schmavery/facebook-chat-api#4ab4380230b58575a9cef9249bfbc1d50973f12d",
         "mkdirp": "^0.5.1",
         "prompt": "^1.0.0",
         "readline": "^1.3.0",
         "winston": "^3.1.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-          "requires": {
-            "lodash": "^4.17.10"
-          }
-        },
-        "winston": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
-          "integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
-          "requires": {
-            "async": "^2.6.1",
-            "diagnostics": "^1.1.1",
-            "is-stream": "^1.1.0",
-            "logform": "^2.1.1",
-            "one-time": "0.0.4",
-            "readable-stream": "^3.1.1",
-            "stack-trace": "0.0.x",
-            "triple-beam": "^1.3.0",
-            "winston-transport": "^4.3.0"
-          }
-        }
       }
     },
     "mime-db": {
@@ -1816,6 +1797,39 @@
         "revalidator": "0.1.x",
         "utile": "0.3.x",
         "winston": "2.1.x"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+        },
+        "winston": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
+          "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
+          "requires": {
+            "async": "~1.0.0",
+            "colors": "1.0.x",
+            "cycle": "1.0.x",
+            "eyes": "0.1.x",
+            "isstream": "0.1.x",
+            "pkginfo": "0.3.x",
+            "stack-trace": "0.0.x"
+          },
+          "dependencies": {
+            "colors": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+              "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+            },
+            "pkginfo": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+              "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE="
+            }
+          }
+        }
       }
     },
     "psl": {
@@ -2009,13 +2023,6 @@
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
         "is-arrayish": "^0.3.1"
-      },
-      "dependencies": {
-        "is-arrayish": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-        }
       }
     },
     "slice-ansi": {
@@ -2283,33 +2290,28 @@
       }
     },
     "winston": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
-      "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
+      "integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
       "requires": {
-        "async": "~1.0.0",
-        "colors": "1.0.x",
-        "cycle": "1.0.x",
-        "eyes": "0.1.x",
-        "isstream": "0.1.x",
-        "pkginfo": "0.3.x",
-        "stack-trace": "0.0.x"
+        "async": "^2.6.1",
+        "diagnostics": "^1.1.1",
+        "is-stream": "^1.1.0",
+        "logform": "^2.1.1",
+        "one-time": "0.0.4",
+        "readable-stream": "^3.1.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.3.0"
       },
       "dependencies": {
         "async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
-        },
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-        },
-        "pkginfo": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
-          "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "^4.17.10"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "messer",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1401,9 +1401,9 @@
       }
     },
     "messen": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/messen/-/messen-0.0.3.tgz",
-      "integrity": "sha512-fwAjzN7lw4hp7AfhaGRO4EtLF7FdUYt7CzlkzVHlCdGShjlPDnfJ9gdrD+oFfiUscisqBhfCcIMBrUx0fDTjPw==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/messen/-/messen-0.0.4.tgz",
+      "integrity": "sha512-nhYxTFtYSenV3uvZcFnwGjQ6xcRF8JeEuWocBSFr8XIULD2odNO+1fv8TlPVn/7UGF4HPXwje6ZBIDLG2MROGw==",
       "requires": {
         "facebook-chat-api": "github:Schmavery/facebook-chat-api#4ab4380230b58575a9cef9249bfbc1d50973f12d",
         "mkdirp": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "chalk": "^2.4.2",
-    "messen": "0.0.1",
+    "messen": "0.0.3",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "prompt": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messer",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Command-line messaging for Facebook Messenger",
   "keywords": [
     "facebook",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "chalk": "^2.4.2",
-    "messen": "0.0.3",
+    "messen": "0.0.4",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "prompt": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "start": "node index.js",
     "lint": "./node_modules/eslint/bin/eslint.js .",
-    "test": "npm run lint && mocha --reporter=\"list\""
+    "test": "mocha --reporter=\"list\""
   },
   "dependencies": {
     "chalk": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "chalk": "^2.4.2",
-    "messen": "0.0.4",
+    "messen": "0.0.5",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "prompt": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint": "^5.13.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.16.0",
-    "mocha": "^5.2.0"
+    "mocha": "^5.2.0",
+    "prettier": "^1.16.4"
   }
 }

--- a/src/commands/command-handlers.js
+++ b/src/commands/command-handlers.js
@@ -186,7 +186,7 @@ const commands = {
 
                       let logText = `${sender.name}: ${message.body}`;
                       if (message.isUnread) logText = chalk.red(logText);
-                      if (message.senderID === this.messy.user.userID) {
+                      if (message.senderID === this.messy.user.id) {
                         logText = chalk.dim(logText);
                       }
 

--- a/src/commands/command-handlers.js
+++ b/src/commands/command-handlers.js
@@ -100,15 +100,14 @@ const commands = {
    */
   [commandTypes.CONTACTS.command]() {
     return new Promise(resolve => {
-      const friendsList = Object.keys(this.messy.user.friendsList);
+      const { friends } = this.messy.user;
+      if (friends.length === 0) return resolve('You have no friends 😢');
 
-      if (friendsList.length === 0) return resolve('You have no friends 😢');
+      const friendsPretty = friends
+        .sort((a, b) => (a.fullName > b.fullName ? 1 : -1))
+        .reduce((a, b) => `${a}${b.fullName}\n`, '');
 
-      const friendsListPretty = friendsList
-        .sort((a, b) => (a > b ? 1 : -1))
-        .reduce((a, b) => `${a}${b}\n`, '');
-
-      return resolve(friendsListPretty);
+      return resolve(friendsPretty);
     });
   },
 

--- a/src/commands/command-handlers.js
+++ b/src/commands/command-handlers.js
@@ -126,10 +126,11 @@ const commands = {
 
   /**
    * Logs the user out of Messer
-   * @return {Promise<String>}
    */
   [commandTypes.LOGOUT.command]() {
-    return new Promise(() => this.messen.logout());
+    return this.messen.logout().then(() => {
+      process.exit();
+    });
   },
 
   /**

--- a/src/commands/command-handlers.js
+++ b/src/commands/command-handlers.js
@@ -1,8 +1,8 @@
-const chalk = require("chalk")
+const chalk = require('chalk');
 
-const helpers = require("../util/helpers")
-const lock = require("../util/lock")
-const commandTypes = require("./command-types")
+const helpers = require('../util/helpers');
+const lock = require('../util/lock');
+const commandTypes = require('./command-types');
 
 /* Store regexps that match raw commands */
 const commandShortcuts = {
@@ -10,7 +10,7 @@ const commandShortcuts = {
   m: commandTypes.MESSAGE,
   r: commandTypes.REPLY,
   c: commandTypes.CLEAR,
-}
+};
 
 /**
  * Matches a raw command on a given regex and returns the available arguments
@@ -19,10 +19,10 @@ const commandShortcuts = {
  * @return {Array<String>}
  */
 function parseCommand(regexp, rawCommand) {
-  if (regexp) return rawCommand.match(regexp)
+  if (regexp) return rawCommand.match(regexp);
 
   // return a 1-item array if no regex i.e. 1 word commands (contacts, etc.)
-  return [rawCommand.trim()]
+  return [rawCommand.trim()];
 }
 
 /**
@@ -37,22 +37,31 @@ const commands = {
    */
   [commandTypes.MESSAGE.command](rawCommand) {
     return new Promise((resolve, reject) => {
-      const argv = parseCommand(commandTypes.MESSAGE.regexp, rawCommand)
-      if (!argv) return reject(Error("Invalid message - check your syntax"))
+      const argv = parseCommand(commandTypes.MESSAGE.regexp, rawCommand);
+      if (!argv) return reject(Error('Invalid message - check your syntax'));
 
-      const rawReceiver = argv[2]
-      const message = argv[3]
+      const rawReceiver = argv[2];
+      const message = argv[3];
 
-      if (message.length === 0) return reject(Error("No message to send - check your syntax"))
-
+      if (message.length === 0) {
+        return reject(Error('No message to send - check your syntax'));
+      }
       return this.getThreadByName(rawReceiver)
-        .then(receiver => this.api.sendMessage(message, receiver.threadID, (err) => {
-          if (err) return reject(err)
+        .then(receiver =>
+          this.messy.api.sendMessage(message, receiver.threadID, err => {
+            if (err) return reject(err);
 
-          return resolve(`Sent message to ${receiver.name}`)
-        }))
-        .catch(() => reject(Error(`User '${rawReceiver}' could not be found in your friends list!`)))
-    })
+            return resolve(`Sent message to ${receiver.name}`);
+          }),
+        )
+        .catch(() =>
+          reject(
+            Error(
+              `User '${rawReceiver}' could not be found in your friends list!`,
+            ),
+          ),
+        );
+    });
   },
 
   /**
@@ -63,20 +72,26 @@ const commands = {
   [commandTypes.REPLY.command](rawCommand) {
     return new Promise((resolve, reject) => {
       if (this.lastThread === null) {
-        return reject(Error("ERROR: You need to receive a message on Messer before using `reply`"))
+        return reject(
+          Error(
+            'ERROR: You need to receive a message on Messer before using `reply`',
+          ),
+        );
       }
 
-      const argv = parseCommand(commandTypes.REPLY.regexp, rawCommand)
-      if (!argv || !argv[2]) return reject(Error("Invalid command - check your syntax"))
+      const argv = parseCommand(commandTypes.REPLY.regexp, rawCommand);
+      if (!argv || !argv[2]) {
+        return reject(Error('Invalid command - check your syntax'));
+      }
 
       // var body = rawCommand.substring(commandTypes.REPLY.length).trim()
 
-      return this.api.sendMessage(argv[2], this.lastThread, (err) => {
-        if (err) return reject(err)
+      return this.messy.api.sendMessage(argv[2], this.lastThread, err => {
+        if (err) return reject(err);
 
-        return resolve()
-      })
-    })
+        return resolve();
+      });
+    });
   },
 
   /**
@@ -84,17 +99,17 @@ const commands = {
    * @return {Promise<String>}
    */
   [commandTypes.CONTACTS.command]() {
-    return new Promise((resolve) => {
-      const friendsList = Object.keys(this.user.friendsList)
+    return new Promise(resolve => {
+      const friendsList = Object.keys(this.messy.user.friendsList);
 
-      if (friendsList.length === 0) return resolve("You have no friends 😢")
+      if (friendsList.length === 0) return resolve('You have no friends 😢');
 
       const friendsListPretty = friendsList
-        .sort((a, b) => ((a) > (b) ? 1 : -1))
-        .reduce((a, b) => `${a}${b}\n`, "")
+        .sort((a, b) => (a > b ? 1 : -1))
+        .reduce((a, b) => `${a}${b}\n`, '');
 
-      return resolve(friendsListPretty)
-    })
+      return resolve(friendsListPretty);
+    });
   },
 
   /**
@@ -105,9 +120,9 @@ const commands = {
     const helpPretty = `Commands:\n${helpers
       .objectValues(commandTypes)
       .filter(command => command.help)
-      .reduce((a, b) => `${a}\t${chalk.blue(b.command)}: ${b.help}\n`, "")}`
+      .reduce((a, b) => `${a}\t${chalk.blue(b.command)}: ${b.help}\n`, '')}`;
 
-    return new Promise(resolve => resolve(helpPretty))
+    return new Promise(resolve => resolve(helpPretty));
   },
 
   /**
@@ -115,7 +130,7 @@ const commands = {
    * @return {Promise<String>}
    */
   [commandTypes.LOGOUT.command]() {
-    return new Promise(() => this.logout())
+    return new Promise(() => this.messy.logout());
   },
 
   /**
@@ -123,7 +138,7 @@ const commands = {
    * @return {Promise<String>}
    */
   [commandTypes.CLEAR.command]() {
-    return new Promise(() => this.clear())
+    return new Promise(() => this.clear());
   },
 
   /**
@@ -133,37 +148,60 @@ const commands = {
    */
   [commandTypes.HISTORY.command](rawCommand) {
     return new Promise((resolve, reject) => {
-      const DEFAULT_COUNT = 5
+      const DEFAULT_COUNT = 5;
 
-      const argv = parseCommand(commandTypes.HISTORY.regexp, rawCommand)
-      if (!argv) return reject(Error("Invalid command - check your syntax"))
-      const rawThreadName = argv[2]
-      const messageCount = argv[3] ? parseInt(argv[3].trim(), 10) : DEFAULT_COUNT
+      const argv = parseCommand(commandTypes.HISTORY.regexp, rawCommand);
+      if (!argv) return reject(Error('Invalid command - check your syntax'));
+      const rawThreadName = argv[2];
+      const messageCount = argv[3]
+        ? parseInt(argv[3].trim(), 10)
+        : DEFAULT_COUNT;
 
       return this.getThreadByName(rawThreadName)
-        .then(thread => this.api.getThreadHistory(thread.threadID, messageCount, undefined,
-          (err, data) => {
-            if (err) return reject(err)
+        .then(thread =>
+          this.messy.api.getThreadHistory(
+            thread.threadID,
+            messageCount,
+            undefined,
+            (err, data) => {
+              if (err) return reject(err);
 
-            if (data.length === 0) return resolve("You haven't started a conversation!")
+              if (data.length === 0) {
+                return resolve("You haven't started a conversation!");
+              }
 
-            const senderIds = Array.from(new Set(data.map(message => message.senderID)))
+              const senderIds = Array.from(
+                new Set(data.map(message => message.senderID)),
+              );
 
-            return Promise.all(senderIds.map(id => this.getThreadById(id, true)))
-              .then(threads => resolve(data
-                .filter(event => event.type === "message")
-                .reduce((a, message) => {
-                  const sender = threads.find(t => t.threadID === message.senderID)
+              return Promise.all(
+                senderIds.map(id => this.getThreadById(id, true)),
+              ).then(threads =>
+                resolve(
+                  data
+                    .filter(event => event.type === 'message')
+                    .reduce((a, message) => {
+                      const sender = threads.find(
+                        t => t.threadID === message.senderID,
+                      );
 
-                  let logText = `${sender.name}: ${message.body}`
-                  if (message.isUnread) logText = chalk.red(logText)
-                  if (message.senderID === this.user.userID) logText = chalk.dim(logText)
+                      let logText = `${sender.name}: ${message.body}`;
+                      if (message.isUnread) logText = chalk.red(logText);
+                      if (message.senderID === this.messy.user.userID) {
+                        logText = chalk.dim(logText);
+                      }
 
-                  return `${a}${logText}\n`
-                }, "")))
-          }))
-        .catch(() => reject(Error(`We couldn't find a thread for '${rawThreadName}'!`)))
-    })
+                      return `${a}${logText}\n`;
+                    }, ''),
+                ),
+              );
+            },
+          ),
+        )
+        .catch(() =>
+          reject(Error(`We couldn't find a thread for '${rawThreadName}'!`)),
+        );
+    });
   },
 
   /**
@@ -173,28 +211,34 @@ const commands = {
    */
   [commandTypes.COLOR.command](rawCommand) {
     return new Promise((resolve, reject) => {
-      const argv = parseCommand(commandTypes.COLOR.regexp, rawCommand)
-      if (!argv) return reject(Error("Invalid command - check your syntax"))
+      const argv = parseCommand(commandTypes.COLOR.regexp, rawCommand);
+      if (!argv) return reject(Error('Invalid command - check your syntax'));
 
-      let color = argv[3]
-      if (!color.startsWith("#")) {
-        color = this.api.threadColors[color]
-        if (!color) return reject(Error(`Color '${argv[3]}' not available`))
+      let color = argv[3];
+      if (!color.startsWith('#')) {
+        color = this.messy.api.threadColors[color];
+        if (!color) return reject(Error(`Color '${argv[3]}' not available`));
       }
       // check if hex code is legit (TODO: regex this)
-      if (color.length !== 7) return reject(Error(`Hex code '${argv[3]}' is not valid`))
+      if (color.length !== 7) {
+        return reject(Error(`Hex code '${argv[3]}' is not valid`));
+      }
 
-      const threadName = argv[2]
+      const threadName = argv[2];
 
       // Find the thread to send to
       return this.getThreadByName(threadName)
-        .then(thread => this.api.changeThreadColor(color, thread.theadID, (err) => {
-          if (err) return reject(err)
+        .then(thread =>
+          this.messy.api.changeThreadColor(color, thread.theadID, err => {
+            if (err) return reject(err);
 
-          return resolve()
-        }))
-        .catch(() => reject(Error(`Thread '${threadName}' couldn't be found!`)))
-    })
+            return resolve();
+          }),
+        )
+        .catch(() =>
+          reject(Error(`Thread '${threadName}' couldn't be found!`)),
+        );
+    });
   },
 
   /**
@@ -204,25 +248,28 @@ const commands = {
    */
   [commandTypes.RECENT.command](rawCommand) {
     return new Promise((resolve, reject) => {
-      const argv = parseCommand(commandTypes.RECENT.regexp, rawCommand)
-      if (!argv) return reject(Error("Invalid command - check your syntax"))
+      const argv = parseCommand(commandTypes.RECENT.regexp, rawCommand);
+      if (!argv) return reject(Error('Invalid command - check your syntax'));
 
-      const DEFAULT_COUNT = 5
+      const DEFAULT_COUNT = 5;
 
-      const threadCount = argv[2] ? parseInt(argv[2].trim(), 10) : DEFAULT_COUNT
+      const threadCount = argv[2]
+        ? parseInt(argv[2].trim(), 10)
+        : DEFAULT_COUNT;
 
-      const threadList = helpers.objectValues(this.threadCache)
+      const threadList = helpers
+        .objectValues(this.threadCache)
         .slice(0, threadCount)
         .sort((a, b) => a.lastMessageTimestamp < b.lastMessageTimestamp)
         .reduce((a, thread, i) => {
-          let logText = `[${i}] ${thread.name}`
-          if (thread.unreadCount) logText = chalk.red(logText)
+          let logText = `[${i}] ${thread.name}`;
+          if (thread.unreadCount) logText = chalk.red(logText);
 
-          return `${a}${logText}\n`
-        }, "")
+          return `${a}${logText}\n`;
+        }, '');
 
-      return resolve(threadList)
-    })
+      return resolve(threadList);
+    });
   },
   /**
    * Displays the most recent n threads
@@ -230,17 +277,29 @@ const commands = {
    */
   [commandTypes.LOCK.command](rawCommand) {
     return new Promise((resolve, reject) => {
-      const receiver = rawCommand.split(" ")
+      const receiver = rawCommand
+        .split(' ')
         .slice(1)
-        .join(" ")
-        .replace("\n", "")
-      if (!receiver) return reject(Error("Please, specify a user to lock on to"))
+        .join(' ')
+        .replace('\n', '');
+      if (!receiver) {
+        return reject(Error('Please, specify a user to lock on to'));
+      }
       return this.getThreadByName(receiver)
         .then(() => {
-          lock.lockOn(receiver)
-          return resolve("Locked on to ".concat(receiver))
-        }).catch(() => reject(Error("Cannot find user ".concat(receiver).concat(" in friends list or active threads"))))
-    })
+          lock.lockOn(receiver);
+          return resolve('Locked on to '.concat(receiver));
+        })
+        .catch(() =>
+          reject(
+            Error(
+              'Cannot find user '
+                .concat(receiver)
+                .concat(' in friends list or active threads'),
+            ),
+          ),
+        );
+    });
   },
 
   /**
@@ -250,14 +309,14 @@ const commands = {
   [commandTypes.UNLOCK.command]() {
     return new Promise((resolve, reject) => {
       if (lock.isLocked()) {
-        const threadName = lock.getLockedTarget()
-        lock.unlock()
-        return resolve("Unlocked form ".concat(threadName))
+        const threadName = lock.getLockedTarget();
+        lock.unlock();
+        return resolve('Unlocked form '.concat(threadName));
       }
-      return reject(Error("No current locked user"))
-    })
+      return reject(Error('No current locked user'));
+    });
   },
-}
+};
 
 module.exports = {
   /**
@@ -266,12 +325,12 @@ module.exports = {
    * @return {Promise}
    */
   getCommandHandler(rawCommandKeyword) {
-    const shortcutCommand = commandShortcuts[rawCommandKeyword]
+    const shortcutCommand = commandShortcuts[rawCommandKeyword];
 
     if (shortcutCommand) {
-      return commands[shortcutCommand.command]
+      return commands[shortcutCommand.command];
     }
 
-    return commands[rawCommandKeyword]
+    return commands[rawCommandKeyword];
   },
-}
+};

--- a/src/commands/command-handlers.js
+++ b/src/commands/command-handlers.js
@@ -1,8 +1,8 @@
-const chalk = require('chalk');
+const chalk = require("chalk");
 
-const helpers = require('../util/helpers');
-const lock = require('../util/lock');
-const commandTypes = require('./command-types');
+const helpers = require("../util/helpers");
+const lock = require("../util/lock");
+const commandTypes = require("./command-types");
 
 /* Store regexps that match raw commands */
 const commandShortcuts = {
@@ -38,13 +38,13 @@ const commands = {
   [commandTypes.MESSAGE.command](rawCommand) {
     return new Promise((resolve, reject) => {
       const argv = parseCommand(commandTypes.MESSAGE.regexp, rawCommand);
-      if (!argv) return reject(Error('Invalid message - check your syntax'));
+      if (!argv) return reject(Error("Invalid message - check your syntax"));
 
       const rawReceiver = argv[2];
       const message = argv[3];
 
       if (message.length === 0) {
-        return reject(Error('No message to send - check your syntax'));
+        return reject(Error("No message to send - check your syntax"));
       }
       return this.getThreadByName(rawReceiver)
         .then(receiver =>
@@ -74,14 +74,14 @@ const commands = {
       if (this.lastThread === null) {
         return reject(
           Error(
-            'ERROR: You need to receive a message on Messer before using `reply`',
+            "ERROR: You need to receive a message on Messer before using `reply`",
           ),
         );
       }
 
       const argv = parseCommand(commandTypes.REPLY.regexp, rawCommand);
       if (!argv || !argv[2]) {
-        return reject(Error('Invalid command - check your syntax'));
+        return reject(Error("Invalid command - check your syntax"));
       }
 
       // var body = rawCommand.substring(commandTypes.REPLY.length).trim()
@@ -101,11 +101,11 @@ const commands = {
   [commandTypes.CONTACTS.command]() {
     return new Promise(resolve => {
       const { friends } = this.messen.user;
-      if (friends.length === 0) return resolve('You have no friends 😢');
+      if (friends.length === 0) return resolve("You have no friends 😢");
 
       const friendsPretty = friends
         .sort((a, b) => (a.fullName > b.fullName ? 1 : -1))
-        .reduce((a, b) => `${a}${b.fullName}\n`, '');
+        .reduce((a, b) => `${a}${b.fullName}\n`, "");
 
       return resolve(friendsPretty);
     });
@@ -119,7 +119,7 @@ const commands = {
     const helpPretty = `Commands:\n${helpers
       .objectValues(commandTypes)
       .filter(command => command.help)
-      .reduce((a, b) => `${a}\t${chalk.blue(b.command)}: ${b.help}\n`, '')}`;
+      .reduce((a, b) => `${a}\t${chalk.blue(b.command)}: ${b.help}\n`, "")}`;
 
     return new Promise(resolve => resolve(helpPretty));
   },
@@ -151,7 +151,7 @@ const commands = {
       const DEFAULT_COUNT = 5;
 
       const argv = parseCommand(commandTypes.HISTORY.regexp, rawCommand);
-      if (!argv) return reject(Error('Invalid command - check your syntax'));
+      if (!argv) return reject(Error("Invalid command - check your syntax"));
       const rawThreadName = argv[2];
       const messageCount = argv[3]
         ? parseInt(argv[3].trim(), 10)
@@ -179,7 +179,7 @@ const commands = {
               ).then(threads =>
                 resolve(
                   data
-                    .filter(event => event.type === 'message')
+                    .filter(event => event.type === "message")
                     .reduce((a, message) => {
                       const sender = threads.find(
                         t => t.threadID === message.senderID,
@@ -192,7 +192,7 @@ const commands = {
                       }
 
                       return `${a}${logText}\n`;
-                    }, ''),
+                    }, ""),
                 ),
               );
             },
@@ -212,10 +212,10 @@ const commands = {
   [commandTypes.COLOR.command](rawCommand) {
     return new Promise((resolve, reject) => {
       const argv = parseCommand(commandTypes.COLOR.regexp, rawCommand);
-      if (!argv) return reject(Error('Invalid command - check your syntax'));
+      if (!argv) return reject(Error("Invalid command - check your syntax"));
 
       let color = argv[3];
-      if (!color.startsWith('#')) {
+      if (!color.startsWith("#")) {
         color = this.messen.api.threadColors[color];
         if (!color) return reject(Error(`Color '${argv[3]}' not available`));
       }
@@ -249,7 +249,7 @@ const commands = {
   [commandTypes.RECENT.command](rawCommand) {
     return new Promise((resolve, reject) => {
       const argv = parseCommand(commandTypes.RECENT.regexp, rawCommand);
-      if (!argv) return reject(Error('Invalid command - check your syntax'));
+      if (!argv) return reject(Error("Invalid command - check your syntax"));
 
       const DEFAULT_COUNT = 5;
 
@@ -266,7 +266,7 @@ const commands = {
           if (thread.unreadCount) logText = chalk.red(logText);
 
           return `${a}${logText}\n`;
-        }, '');
+        }, "");
 
       return resolve(threadList);
     });
@@ -278,24 +278,24 @@ const commands = {
   [commandTypes.LOCK.command](rawCommand) {
     return new Promise((resolve, reject) => {
       const receiver = rawCommand
-        .split(' ')
+        .split(" ")
         .slice(1)
-        .join(' ')
-        .replace('\n', '');
+        .join(" ")
+        .replace("\n", "");
       if (!receiver) {
-        return reject(Error('Please, specify a user to lock on to'));
+        return reject(Error("Please, specify a user to lock on to"));
       }
       return this.getThreadByName(receiver)
         .then(() => {
           lock.lockOn(receiver);
-          return resolve('Locked on to '.concat(receiver));
+          return resolve("Locked on to ".concat(receiver));
         })
         .catch(() =>
           reject(
             Error(
-              'Cannot find user '
+              "Cannot find user "
                 .concat(receiver)
-                .concat(' in friends list or active threads'),
+                .concat(" in friends list or active threads"),
             ),
           ),
         );
@@ -311,9 +311,9 @@ const commands = {
       if (lock.isLocked()) {
         const threadName = lock.getLockedTarget();
         lock.unlock();
-        return resolve('Unlocked form '.concat(threadName));
+        return resolve("Unlocked form ".concat(threadName));
       }
-      return reject(Error('No current locked user'));
+      return reject(Error("No current locked user"));
     });
   },
 };

--- a/src/commands/command-handlers.js
+++ b/src/commands/command-handlers.js
@@ -128,9 +128,7 @@ const commands = {
    * Logs the user out of Messer
    */
   [commandTypes.LOGOUT.command]() {
-    return this.messen.logout().then(() => {
-      process.exit();
-    });
+    return this.logout();
   },
 
   /**

--- a/src/commands/command-types.js
+++ b/src/commands/command-types.js
@@ -7,49 +7,49 @@ const regexps = [
 /* Command type constants */
 const commandTypes = {
   COLOR: {
-    command: 'color',
+    command: "color",
     regexp: regexps[0],
   },
   CONTACTS: {
-    command: 'contacts',
-    help: 'contacts',
+    command: "contacts",
+    help: "contacts",
   },
   HELP: {
-    command: 'help',
+    command: "help",
   },
   LOGOUT: {
-    command: 'logout',
+    command: "logout",
   },
   HISTORY: {
-    command: 'history',
+    command: "history",
     regexp: regexps[2],
     help: 'history "[thread name]" [n]',
   },
   MESSAGE: {
-    command: 'message',
+    command: "message",
     regexp: regexps[0],
     help: 'message "[thread name]" [message]',
   },
   RECENT: {
-    command: 'recent',
+    command: "recent",
     regexp: regexps[1],
-    help: 'recent [n]',
+    help: "recent [n]",
   },
   REPLY: {
-    command: 'reply',
+    command: "reply",
     regexp: regexps[1],
-    help: 'reply [message]',
+    help: "reply [message]",
   },
   CLEAR: {
-    command: 'clear',
+    command: "clear",
   },
   LOCK: {
-    command: 'lock',
-    help: 'lock [thread name]',
+    command: "lock",
+    help: "lock [thread name]",
   },
   UNLOCK: {
-    command: 'unlock',
-    help: 'unlock',
+    command: "unlock",
+    help: "unlock",
   },
 };
 

--- a/src/commands/command-types.js
+++ b/src/commands/command-types.js
@@ -2,55 +2,55 @@ const regexps = [
   /([A-z]+)\s+"(.*?)"\s+(.+)/,
   /([A-z]+)\s+(.+){0,}/,
   /([A-z]+)\s+"(.*?)"(?:\s+)?([0-9]+)?/,
-]
+];
 
 /* Command type constants */
 const commandTypes = {
   COLOR: {
-    command: "color",
+    command: 'color',
     regexp: regexps[0],
   },
   CONTACTS: {
-    command: "contacts",
-    help: "contacts",
+    command: 'contacts',
+    help: 'contacts',
   },
   HELP: {
-    command: "help",
+    command: 'help',
   },
   LOGOUT: {
-    command: "logout",
+    command: 'logout',
   },
   HISTORY: {
-    command: "history",
+    command: 'history',
     regexp: regexps[2],
-    help: "history \"[thread name]\" [n]",
+    help: 'history "[thread name]" [n]',
   },
   MESSAGE: {
-    command: "message",
+    command: 'message',
     regexp: regexps[0],
-    help: "message \"[thread name]\" [message]",
+    help: 'message "[thread name]" [message]',
   },
   RECENT: {
-    command: "recent",
+    command: 'recent',
     regexp: regexps[1],
-    help: "recent [n]",
+    help: 'recent [n]',
   },
   REPLY: {
-    command: "reply",
+    command: 'reply',
     regexp: regexps[1],
-    help: "reply [message]",
+    help: 'reply [message]',
   },
   CLEAR: {
-    command: "clear",
+    command: 'clear',
   },
   LOCK: {
-    command: "lock",
-    help: "lock [thread name]",
+    command: 'lock',
+    help: 'lock [thread name]',
   },
   UNLOCK: {
-    command: "unlock",
-    help: "unlock",
+    command: 'unlock',
+    help: 'unlock',
   },
-}
+};
 
-module.exports = commandTypes
+module.exports = commandTypes;

--- a/src/event-handlers.js
+++ b/src/event-handlers.js
@@ -1,6 +1,6 @@
-const log = require('./util/log');
-const fbAssets = require('./fb-assets');
-const helpers = require('./util/helpers.js');
+const log = require("./util/log");
+const fbAssets = require("./fb-assets");
+const helpers = require("./util/helpers.js");
 
 /**
  * Returns the parsed attachment object as a String
@@ -8,29 +8,29 @@ const helpers = require('./util/helpers.js');
  * @return {String}
  */
 function parseAttachment(attachment) {
-  const attachmentType = attachment.type.replace(/_/g, ' ');
+  const attachmentType = attachment.type.replace(/_/g, " ");
 
-  let messageBody = '';
+  let messageBody = "";
 
   switch (attachmentType) {
-    case 'sticker':
+    case "sticker":
       try {
         messageBody =
           fbAssets.facebookStickers[attachment.packID][attachment.stickerID];
       } catch (e) {
-        messageBody = 'sent a sticker (only viewable in browser)';
+        messageBody = "sent a sticker (only viewable in browser)";
       }
       break;
-    case 'file':
+    case "file":
       messageBody = `${attachment.name}: ${attachment.url}`;
       break;
-    case 'photo':
+    case "photo":
       messageBody = `${attachment.filename}: ${attachment.facebookUrl}`;
       break;
-    case 'share':
+    case "share":
       messageBody = `${attachment.facebookUrl}`;
       break;
-    case 'video':
+    case "video":
       messageBody = `${attachment.filename}: ${attachment.url}`;
       break;
     default:
@@ -66,7 +66,7 @@ const eventHandlers = {
         if (ev.attachments.length > 0) {
           messageBody = ev.attachments.reduce(
             (prev, curr) => `${prev} ${parseAttachment(curr)};`,
-            '',
+            "",
           );
         }
 
@@ -76,7 +76,7 @@ const eventHandlers = {
               sender = `(${thread.name}) ${threadSender.name}`; // Get true sender name from list
               log(
                 `${
-                  this.lastThread !== ev.threadID ? '\n' : ''
+                  this.lastThread !== ev.threadID ? "\n" : ""
                 }${sender} - ${messageBody}`,
                 thread.color,
               );
@@ -85,7 +85,7 @@ const eventHandlers = {
               sender = `(${thread.name}) ${sender.name}`; // Sender not in list, keep origin
               log(
                 `${
-                  this.lastThread !== ev.threadID ? '\n' : ''
+                  this.lastThread !== ev.threadID ? "\n" : ""
                 }${sender} - ${messageBody}`,
                 thread.color,
               );
@@ -93,7 +93,7 @@ const eventHandlers = {
         } else {
           log(
             `${
-              this.lastThread !== ev.threadID ? '\n' : ''
+              this.lastThread !== ev.threadID ? "\n" : ""
             }${sender} - ${messageBody}`,
             thread.color,
           );
@@ -103,7 +103,7 @@ const eventHandlers = {
 
         helpers.notifyTerminal(this.unreadMessagesCount); // Terminal notification in title
 
-        process.stderr.write('\x07'); // Terminal notification
+        process.stderr.write("\x07"); // Terminal notification
         this.lastThread = ev.threadID;
       })
       .catch(err => log(err));
@@ -114,10 +114,10 @@ const eventHandlers = {
    */
   event(ev) {
     this.getThreadById(ev.threadID).then(thread => {
-      let logMessage = 'An event happened!';
+      let logMessage = "An event happened!";
 
       switch (ev.logMessageType) {
-        case 'log:thread-color':
+        case "log:thread-color":
           Object.assign(thread, {
             color: `#${ev.logMessageData.theme_color.slice(2)}`,
           });

--- a/src/event-handlers.js
+++ b/src/event-handlers.js
@@ -50,25 +50,25 @@ const eventHandlers = {
    * Handles the "message" event type
    * @param {Object} message - message to handle
    */
-  message(message) {
-    this.getThreadById(message.threadID)
+  message(ev) {
+    if (
+      ev.senderID === this.messy.user.id &&
+      ev.threadID !== this.messy.user.id
+    ) {
+      return;
+    }
+
+    this.getThreadById(ev.threadID)
       .then(thread => {
-        if (
-          message.senderID === this.user.userID &&
-          message.threadID !== this.user.userID
-        ) {
-          return;
-        }
-
         let sender = thread.name;
-        let messageBody = message.body;
+        let messageBody = ev.body;
 
-        if (message.isGroup) {
+        if (ev.isGroup) {
           sender = `(${thread.name}) ${sender}`;
         }
 
-        if (message.attachments.length > 0) {
-          messageBody = message.attachments.reduce(
+        if (ev.attachments.length > 0) {
+          messageBody = ev.attachments.reduce(
             (prev, curr) => `${prev} ${parseAttachment(curr)};`,
             '',
           );
@@ -76,7 +76,7 @@ const eventHandlers = {
 
         log(
           `${
-            this.lastThread !== message.threadID ? '\n' : ''
+            this.lastThread !== ev.threadID ? '\n' : ''
           }${sender} - ${messageBody}`,
           thread.color,
         );
@@ -85,7 +85,7 @@ const eventHandlers = {
         helpers.notifyTerminal(this.unreadMessagesCount); // Terminal notification in title
 
         process.stderr.write('\x07'); // Terminal notification
-        this.lastThread = message.threadID;
+        this.lastThread = ev.threadID;
       })
       .catch(err => log(err));
   },

--- a/src/event-handlers.js
+++ b/src/event-handlers.js
@@ -1,6 +1,6 @@
-const log = require("./util/log")
-const fbAssets = require("./fb-assets")
-const helpers = require("./util/helpers.js")
+const log = require('./util/log');
+const fbAssets = require('./fb-assets');
+const helpers = require('./util/helpers.js');
 
 /**
  * Returns the parsed attachment object as a String
@@ -8,36 +8,37 @@ const helpers = require("./util/helpers.js")
  * @return {String}
  */
 function parseAttachment(attachment) {
-  const attachmentType = attachment.type.replace(/_/g, " ")
+  const attachmentType = attachment.type.replace(/_/g, ' ');
 
-  let messageBody = ""
+  let messageBody = '';
 
   switch (attachmentType) {
-    case "sticker":
+    case 'sticker':
       try {
-        messageBody = fbAssets.facebookStickers[attachment.packID][attachment.stickerID]
+        messageBody =
+          fbAssets.facebookStickers[attachment.packID][attachment.stickerID];
       } catch (e) {
-        messageBody = "sent a sticker (only viewable in browser)"
+        messageBody = 'sent a sticker (only viewable in browser)';
       }
-      break
-    case "file":
-      messageBody = `${attachment.name}: ${attachment.url}`
-      break
-    case "photo":
-      messageBody = `${attachment.filename}: ${attachment.facebookUrl}`
-      break
-    case "share":
-      messageBody = `${attachment.facebookUrl}`
-      break
-    case "video":
-      messageBody = `${attachment.filename}: ${attachment.url}`
-      break
+      break;
+    case 'file':
+      messageBody = `${attachment.name}: ${attachment.url}`;
+      break;
+    case 'photo':
+      messageBody = `${attachment.filename}: ${attachment.facebookUrl}`;
+      break;
+    case 'share':
+      messageBody = `${attachment.facebookUrl}`;
+      break;
+    case 'video':
+      messageBody = `${attachment.filename}: ${attachment.url}`;
+      break;
     default:
-      messageBody = `sent [${attachmentType}] - only viewable in browser`
-      break
+      messageBody = `sent [${attachmentType}] - only viewable in browser`;
+      break;
   }
 
-  return `[${attachmentType}] ${messageBody}`
+  return `[${attachmentType}] ${messageBody}`;
 }
 
 /**
@@ -51,60 +52,68 @@ const eventHandlers = {
    */
   message(message) {
     this.getThreadById(message.threadID)
-      .then((thread) => {
-        if (message.senderID === this.user.userID && message.threadID !== this.user.userID) return
+      .then(thread => {
+        if (
+          message.senderID === this.user.userID &&
+          message.threadID !== this.user.userID
+        ) {
+          return;
+        }
 
-        let sender = thread.name
-        let messageBody = message.body
+        let sender = thread.name;
+        let messageBody = message.body;
 
         if (message.isGroup) {
-          sender = `(${thread.name}) ${sender}`
+          sender = `(${thread.name}) ${sender}`;
         }
 
         if (message.attachments.length > 0) {
-          messageBody = message.attachments.reduce((prev, curr) => `${prev} ${parseAttachment(curr)};`, "")
+          messageBody = message.attachments.reduce(
+            (prev, curr) => `${prev} ${parseAttachment(curr)};`,
+            '',
+          );
         }
 
-        log(`${this.lastThread !== message.threadID ? "\n" : ""}${sender} - ${messageBody}`, thread.color)
-        this.unreadMessagesCount += 1
+        log(
+          `${
+            this.lastThread !== message.threadID ? '\n' : ''
+          }${sender} - ${messageBody}`,
+          thread.color,
+        );
+        this.unreadMessagesCount += 1;
 
-        helpers.notifyTerminal(this.unreadMessagesCount) // Terminal notification in title
+        helpers.notifyTerminal(this.unreadMessagesCount); // Terminal notification in title
 
-        process.stderr.write("\x07") // Terminal notification
-        this.lastThread = message.threadID
+        process.stderr.write('\x07'); // Terminal notification
+        this.lastThread = message.threadID;
       })
-      .catch(err => log(err))
+      .catch(err => log(err));
   },
   /**
    * Handles the "event" event type
    * @param {Object} ev - event to handle
    */
   event(ev) {
-    this.getThreadById(ev.threadID)
-      .then((thread) => {
-        let logMessage = "An event happened!"
+    this.getThreadById(ev.threadID).then(thread => {
+      let logMessage = 'An event happened!';
 
-        switch (ev.logMessageType) {
-          case "log:thread-color":
-            Object.assign(thread, { color: `#${ev.logMessageData.theme_color.slice(2)}` })
-            logMessage = ev.logMessageBody
-            break
-          default:
-            break
-        }
+      switch (ev.logMessageType) {
+        case 'log:thread-color':
+          Object.assign(thread, {
+            color: `#${ev.logMessageData.theme_color.slice(2)}`,
+          });
+          logMessage = ev.logMessageBody;
+          break;
+        default:
+          break;
+      }
 
-        log(logMessage)
-      })
+      log(logMessage);
+    });
   },
-  typ() {
+  typ() {},
+  read_receipt() {},
+  message_reaction() {},
+};
 
-  },
-  read_receipt() {
-
-  },
-  message_reaction() {
-
-  },
-}
-
-module.exports = eventHandlers
+module.exports = eventHandlers;

--- a/src/fb-assets.js
+++ b/src/fb-assets.js
@@ -6,7 +6,7 @@ module.exports = {
    */
   facebookStickers: {
     227877430692340: {
-      369239263222822: ":thumbsup:",
+      369239263222822: ':thumbsup:',
     },
   },
-}
+};

--- a/src/fb-assets.js
+++ b/src/fb-assets.js
@@ -6,7 +6,7 @@ module.exports = {
    */
   facebookStickers: {
     227877430692340: {
-      369239263222822: ':thumbsup:',
+      369239263222822: ":thumbsup:",
     },
   },
 };

--- a/src/messer.js
+++ b/src/messer.js
@@ -1,11 +1,11 @@
-const Messen = require('messen');
-const repl = require('repl');
+const Messen = require("messen");
+const repl = require("repl");
 
-const helpers = require('./util/helpers.js');
-const { getCommandHandler } = require('./commands/command-handlers');
-const eventHandlers = require('./event-handlers');
-const log = require('./util/log');
-const lock = require('./util/lock');
+const helpers = require("./util/helpers.js");
+const { getCommandHandler } = require("./commands/command-handlers");
+const eventHandlers = require("./event-handlers");
+const log = require("./util/log");
+const lock = require("./util/lock");
 
 const getMessen = ctx => {
   const messen = new Messen();
@@ -44,8 +44,8 @@ function Messer(options = {}) {
  */
 Messer.prototype.refreshThreadList = function refreshThreadList() {
   return new Promise((resolve, reject) =>
-    this.messen.api.getThreadList(20, null, ['INBOX'], (err, threads) => {
-      if (!threads) return reject(Error('Nothing returned from getThreadList'));
+    this.messen.api.getThreadList(20, null, ["INBOX"], (err, threads) => {
+      if (!threads) return reject(Error("Nothing returned from getThreadList"));
 
       threads.forEach(thread => this.cacheThread(thread));
       return resolve();
@@ -104,25 +104,25 @@ Messer.prototype.processCommand = function processCommand(rawCommand) {
   // ignore if rawCommand is only spaces
   if (localCommand.trim().length === 0) return Promise.resolve();
 
-  const args = localCommand.replace('\n', '').split(' ');
+  const args = localCommand.replace("\n", "").split(" ");
 
   let commandHandler = getCommandHandler(args[0]);
 
   if (lock.isLocked()) {
-    if (localCommand.trim() === 'unlock') {
-      commandHandler = getCommandHandler('unlock');
+    if (localCommand.trim() === "unlock") {
+      commandHandler = getCommandHandler("unlock");
     } else {
-      commandHandler = getCommandHandler('m');
-      localCommand = 'm '
+      commandHandler = getCommandHandler("m");
+      localCommand = "m "
         .concat('"')
         .concat(lock.getLockedTarget())
         .concat('" ')
-        .concat(args.join(' '));
+        .concat(args.join(" "));
     }
   }
 
   if (!commandHandler) {
-    return Promise.reject(Error('Invalid command - check your syntax'));
+    return Promise.reject(Error("Invalid command - check your syntax"));
   }
 
   return commandHandler.call(this, localCommand);
@@ -165,7 +165,7 @@ Messer.prototype.getThreadByName = function getThreadByName(threadName) {
       );
 
       if (!friend) {
-        return reject(Error('No threadID could be found.'));
+        return reject(Error("No threadID could be found."));
       }
 
       // create a fake thread based off friend info
@@ -219,7 +219,7 @@ Messer.prototype.getThreadById = function getThreadById(
           );
 
           if (!friend) {
-            return reject(Error('Friend could not be found for thread'));
+            return reject(Error("Friend could not be found for thread"));
           }
 
           friendName = friend.fullName;

--- a/src/messer.js
+++ b/src/messer.js
@@ -1,202 +1,126 @@
-const facebook = require("facebook-chat-api")
-const repl = require("repl")
-const fs = require("fs")
+const Messy = require('messy');
+const repl = require('repl');
 
-const helpers = require("./util/helpers.js")
-const { getCommandHandler } = require("./commands/command-handlers")
-const eventHandlers = require("./event-handlers")
-const log = require("./util/log")
-const settings = require("./settings")
-const lock = require("./util/lock")
+const helpers = require('./util/helpers.js');
+const { getCommandHandler } = require('./commands/command-handlers');
+const eventHandlers = require('./event-handlers');
+const log = require('./util/log');
+const lock = require('./util/lock');
+
+const getMessy = () => {
+  const messy = new Messy();
+
+  messy.getMfaCode = () => helpers.promptCode();
+  messy.promptCredentials = () => helpers.promptCredentials();
+  messy.onMessage = ev => eventHandlers.message(ev);
+  messy.onThreadEvent = ev => eventHandlers.event(ev);
+
+  return messy;
+};
 
 /**
  * Creates a singleton that represents a Messer session.
  * @class
  */
 function Messer(options = {}) {
-  this.api = null
-  this.user = null
+  this.messy = getMessy();
 
-  this.threadCache = {} // cached by id
-  this.threadNameToIdMap = {} // maps a thread name to a thread id
+  this.threadCache = {}; // cached by id
+  this.threadNameToIdMap = {}; // maps a thread name to a thread id
 
-  this.lastThread = null
-  this.unreadMessagesCount = 0
-  this.debug = options.debug || false
-}
-
-/**
- * Perform inital load of, or refresh, user info.
- */
-Messer.prototype.getOrRefreshUserInfo = function getOrRefreshUserInfo() {
-  return new Promise((resolve, reject) => {
-    const userId = this.api.getCurrentUserID()
-    if (this.user === null) this.user = {}
-
-    return this.api.getUserInfo(userId, (err, data) => {
-      if (err) return reject(err)
-
-      Object.assign(this.user, data[userId])
-      this.user.userID = userId // set userId, because the api doesn't
-
-      return resolve(this.user)
-    })
-  })
-}
-
-/**
- * Refresh user's friends list
- */
-Messer.prototype.refreshFriendsList = function refreshFriendsList() {
-  return new Promise((resolve, reject) => this.api.getFriendsList((err, data) => {
-    if (err) return reject(err)
-
-    this.user.friendsList = {}
-
-    // store friends by name
-    data.forEach((friend) => {
-      this.user.friendsList[friend.fullName] = friend
-    })
-
-    return resolve(this.user)
-  }))
+  this.lastThread = null;
+  this.unreadMessagesCount = 0;
+  this.debug = options.debug || false;
 }
 
 /**
  * Refresh the thread list.
  */
 Messer.prototype.refreshThreadList = function refreshThreadList() {
-  return new Promise((resolve, reject) => this.api.getThreadList(20, null, ["INBOX"], (err, threads) => {
-    if (!threads) return reject(Error("Nothing returned from getThreadList"))
+  return new Promise((resolve, reject) =>
+    this.messy.api.getThreadList(20, null, ['INBOX'], (err, threads) => {
+      if (!threads) return reject(Error('Nothing returned from getThreadList'));
 
-    threads.forEach(thread => this.cacheThread(thread))
-    return resolve()
-  }))
-}
-
-Messer.prototype.fetchUser = function fetchUser() {
-  return Promise.all([
-    this.getOrRefreshUserInfo(),
-    this.refreshFriendsList(),
-    this.refreshThreadList(),
-  ])
-}
-
-/**
- * Authenticates a user with Facebook. Prompts for credentials if argument is undefined.
- * @param {Object} credentials - The Facebook credentials of the user
- * @param {string} email - The user's Facebook email
- * @param {string} credentials.password - The user's Facebook password
- * @return {Promise<null>}
- */
-Messer.prototype.authenticate = function authenticate(credentials) {
-  log("Logging in...")
-
-  const config = {
-    forceLogin: true,
-    logLevel: this.debug ? "info" : "silent",
-    selfListen: true,
-    listenEvents: true,
-  }
-
-  return new Promise((resolve, reject) => {
-    facebook(credentials, config, (err, fbApi) => {
-      if (err) {
-        switch (err.error) {
-          case "login-approval":
-            helpers.promptCode().then(code => err.continue(code))
-            break
-          default:
-            return reject(Error(`Failed to login as [${credentials.email}] - ${err}`))
-        }
-        return null
-      }
-
-      return helpers.saveAppState(fbApi.getAppState(), settings.APPSTATE_FILE_PATH)
-        .then(() => {
-          this.api = fbApi
-
-          return resolve()
-        })
-        .catch(appstateErr => reject(appstateErr))
-    })
-  })
-}
+      threads.forEach(thread => this.cacheThread(thread));
+      return resolve();
+    }),
+  );
+};
 
 /**
  * Starts a Messer session.
  */
 Messer.prototype.start = function start() {
-  helpers.notifyTerminal()
+  helpers.notifyTerminal();
 
-  helpers.getCredentials(settings.APPSTATE_FILE_PATH)
-    .then(credentials => this.authenticate(credentials))
-    .then(() => this.getOrRefreshUserInfo())
-    .then(() => this.fetchUser())
+  this.messy
+    .login()
     .then(() => {
-      log(`Successfully logged in as ${this.user.name}`)
+      log(`Successfully logged in as ${this.messy.user.name}`);
 
-      this.api.listen((err, ev) => {
-        if (err) return null
-
-        return eventHandlers[ev.type].call(this, ev)
-      })
+      this.messy.listen();
 
       repl.start({
         ignoreUndefined: true,
-        eval: (input, context, filename, cb) => this.processCommand(input)
-          .then((res) => { log(res); cb(null) })
-          .catch((err) => { log(err.message); cb(null) }),
-      })
+        eval: (input, context, filename, cb) =>
+          this.processCommand(input)
+            .then(res => {
+              log(res);
+              cb(null);
+            })
+            .catch(err => {
+              log(err.message);
+              cb(null);
+            }),
+      });
     })
-    .catch(err => log(err))
-}
+    .catch(err => log(err));
+};
 /**
  * Starts Messer and executes a single command
  */
 Messer.prototype.startSingle = function startSingle(rawCommand) {
-  helpers.getCredentials(settings.APPSTATE_FILE_PATH)
-    .then(credentials => this.authenticate(credentials))
-    .then(() => this.getOrRefreshUserInfo())
-    .then(() => this.fetchUser())
+  this.messy
+    .login()
     .then(() => this.processCommand(rawCommand))
-    .catch(err => log(err))
-}
+    .catch(err => log(err));
+};
 /**
  * Execute appropriate action for user input commands.
  * @param {String} rawCommand - command to process
  * @return {Promise}
  */
 Messer.prototype.processCommand = function processCommand(rawCommand) {
-  this.clear() // If we are typing, new messages have been read
+  this.clear(); // If we are typing, new messages have been read
 
-  let commandHandler = null
-  let localCommand = rawCommand
+  let localCommand = rawCommand;
 
   // ignore if rawCommand is only spaces
-  if (localCommand.trim().length === 0) return Promise.resolve()
+  if (localCommand.trim().length === 0) return Promise.resolve();
 
-  const args = localCommand.replace("\n", "").split(" ")
-  commandHandler = getCommandHandler(args[0])
+  const args = localCommand.replace('\n', '').split(' ');
+
+  let commandHandler = getCommandHandler(args[0]);
 
   if (lock.isLocked()) {
-    if (localCommand.trim() === "unlock") {
-      commandHandler = getCommandHandler("unlock")
+    if (localCommand.trim() === 'unlock') {
+      commandHandler = getCommandHandler('unlock');
     } else {
-      commandHandler = getCommandHandler("m")
-      localCommand = "m ".concat("\"")
+      commandHandler = getCommandHandler('m');
+      localCommand = 'm '
+        .concat('"')
         .concat(lock.getLockedTarget())
-        .concat("\" ")
-        .concat(args.join(" "))
+        .concat('" ')
+        .concat(args.join(' '));
     }
   }
 
   if (!commandHandler) {
-    return Promise.reject(Error("Invalid command - check your syntax"))
+    return Promise.reject(Error('Invalid command - check your syntax'));
   }
 
-  return commandHandler.call(this, localCommand)
-}
+  return commandHandler.call(this, localCommand);
+};
 
 /**
  * Adds a thread node to the thread cache.
@@ -209,12 +133,12 @@ Messer.prototype.cacheThread = function cacheThread(thread) {
     color: thread.color,
     lastMessageTimestamp: thread.lastMessageTimestamp,
     unreadCount: thread.unreadCount,
-  } // only cache the info we need
+  }; // only cache the info we need
 
   if (thread.name) {
-    this.threadNameToIdMap[thread.name] = thread.threadID
+    this.threadNameToIdMap[thread.name] = thread.threadID;
   }
-}
+};
 
 /**
  * Gets thread by thread name. Will select the thread with name starting with the given name.
@@ -222,100 +146,97 @@ Messer.prototype.cacheThread = function cacheThread(thread) {
  */
 Messer.prototype.getThreadByName = function getThreadByName(threadName) {
   return new Promise((resolve, reject) => {
-    const fullThreadName = Object.keys(this.threadNameToIdMap)
-      .find(n => n.toLowerCase().startsWith(threadName.toLowerCase()))
+    const fullThreadName = Object.keys(this.threadNameToIdMap).find(n =>
+      n.toLowerCase().startsWith(threadName.toLowerCase()),
+    );
 
-    const threadID = this.threadNameToIdMap[fullThreadName]
+    const threadID = this.threadNameToIdMap[fullThreadName];
 
     // if thread not cached, try the friends list
     if (!threadID) {
-      const friendName = Object.keys(this.user.friendsList)
-        .find(n => n.toLowerCase().startsWith(threadName.toLowerCase()))
+      const friendName = Object.keys(this.messy.user.friendsList).find(n =>
+        n.toLowerCase().startsWith(threadName.toLowerCase()),
+      );
 
       if (!friendName) {
-        return reject(Error("No threadID could be found."))
+        return reject(Error('No threadID could be found.'));
       }
 
       // create a fake thread based off friend info
       const friendThread = {
         name: friendName,
-        threadID: this.user.friendsList[friendName].userID,
-      }
+        threadID: this.messy.user.friendsList[friendName].userID,
+      };
 
-      return resolve(friendThread)
+      return resolve(friendThread);
     }
 
     return this.getThreadById(threadID)
-      .then((thread) => {
+      .then(thread => {
         if (!thread.name) {
-          Object.assign(thread, { name: threadName })
+          Object.assign(thread, { name: threadName });
         }
 
-        return resolve(thread)
+        return resolve(thread);
       })
-      .catch(err => reject(err))
-  })
-}
+      .catch(err => reject(err));
+  });
+};
 
 /**
  * Gets thread by threadID.
  * @param {String} threadID - threadID of desired thread
  * @param {Boolean} requireName - specifies if the thread name is absolutely necessary
  */
-Messer.prototype.getThreadById = function getThreadById(threadID, requireName = false) {
+Messer.prototype.getThreadById = function getThreadById(
+  threadID,
+  requireName = false,
+) {
   return new Promise((resolve, reject) => {
-    let thread = this.threadCache[threadID]
+    let thread = this.threadCache[threadID];
 
-    if (thread) return resolve(thread)
+    if (thread) return resolve(thread);
 
-    return this.api.getThreadInfo(threadID, (err, data) => {
-      if (err) return reject(err)
-      thread = data
+    return this.messy.api.getThreadInfo(threadID, (err, data) => {
+      if (err) return reject(err);
+      thread = data;
 
       // try to get thread name from friends list
       if (!thread.name && requireName) {
-        let friendName = null
+        let friendName = null;
 
-        if (threadID === this.user.userID) {
-          friendName = this.user.name
+        if (threadID === this.messy.user.userID) {
+          friendName = this.messy.user.name;
         } else {
-          const friend = helpers.objectValues(this.user.friendsList)
-            .find(user => user.userID === threadID)
+          const friend = helpers
+            .objectValues(this.messy.user.friendsList)
+            .find(user => user.userID === threadID);
 
           if (!friend) {
-            return reject(Error("Name could not be found for thread"))
+            return reject(Error('Name could not be found for thread'));
           }
 
-          friendName = friend.fullName
+          friendName = friend.fullName;
         }
 
-        thread.name = friendName
+        thread.name = friendName;
       }
 
-      this.cacheThread(thread)
+      this.cacheThread(thread);
 
-      return resolve(thread)
-    })
-  })
-}
+      return resolve(thread);
+    });
+  });
+};
 
 /**
  * Clears the messer notification in the terminal title.
  */
 Messer.prototype.clear = function clear() {
-  if (this.unreadMessagesCount === 0) return
+  if (this.unreadMessagesCount === 0) return;
 
-  this.unreadMessagesCount = 0
-  helpers.notifyTerminal()
-}
+  this.unreadMessagesCount = 0;
+  helpers.notifyTerminal();
+};
 
-/**
- * Terminates the Messer session and removes all relevent files.
- */
-Messer.prototype.logout = function logout() {
-  fs.unlink(settings.APPSTATE_FILE_PATH, () => {
-    process.exit()
-  })
-}
-
-module.exports = Messer
+module.exports = Messer;

--- a/src/messer.js
+++ b/src/messer.js
@@ -32,7 +32,7 @@ const getMessy = ctx => {
  * @class
  */
 function Messer(options = {}) {
-  this.messy = undefined;
+  this.messy = getMessy(this);
 
   this.threadCache = {}; // cached by id
   this.threadNameToIdMap = {}; // maps a thread name to a thread id
@@ -60,7 +60,6 @@ Messer.prototype.refreshThreadList = function refreshThreadList() {
  * Starts a Messer session.
  */
 Messer.prototype.start = function start() {
-  this.messy = getMessy(this);
   helpers.notifyTerminal();
 
   this.messy
@@ -215,7 +214,7 @@ Messer.prototype.getThreadById = function getThreadById(
       if (!thread.name && requireName) {
         let friendName = null;
 
-        if (threadID === this.messy.user.userID) {
+        if (threadID === this.messy.user.id) {
           friendName = this.messy.user.name;
         } else {
           const friend = this.messy.user.friends.find(
@@ -223,7 +222,7 @@ Messer.prototype.getThreadById = function getThreadById(
           );
 
           if (!friend) {
-            return reject(Error('Name could not be found for thread'));
+            return reject(Error('Friend could not be found for thread'));
           }
 
           friendName = friend.fullName;

--- a/src/messer.js
+++ b/src/messer.js
@@ -7,6 +7,9 @@ const eventHandlers = require('./event-handlers');
 const log = require('./util/log');
 const lock = require('./util/lock');
 
+/**
+ * Let's get messy
+ */
 const getMessy = () => {
   const messy = new Messy();
 

--- a/src/messer.js
+++ b/src/messer.js
@@ -246,7 +246,7 @@ Messer.prototype.clear = function clear() {
 };
 
 /**
- * Clears the messer notification in the terminal title.
+ * Terminates the Messer session and removes all relevent files.
  */
 Messer.prototype.logout = function logout() {
   return this.messen.logout().then(() => {

--- a/src/messer.js
+++ b/src/messer.js
@@ -245,4 +245,13 @@ Messer.prototype.clear = function clear() {
   helpers.notifyTerminal();
 };
 
+/**
+ * Clears the messer notification in the terminal title.
+ */
+Messer.prototype.logout = function logout() {
+  return this.messen.logout().then(() => {
+    process.exit();
+  });
+};
+
 module.exports = Messer;

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,9 +1,0 @@
-const path = require("path")
-
-const MESSER_PATH = path.resolve(process.env.HOME, ".messer")
-const APPSTATE_FILE_PATH = path.resolve(MESSER_PATH, "tmp/appstate.json")
-
-module.exports = {
-  APPSTATE_FILE_PATH,
-  MESSER_PATH,
-}

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -68,27 +68,6 @@ function promptCode() {
 }
 
 /**
- * Dumps the state of the Facebook API to a file
- * @param {Object} appstate object generated from fbApi.getAppState() method
- * @param {string} filepath file to save appstate to
- * @return {Promise}
- */
-function saveAppState(appstate, filepath) {
-  return new Promise((resolve, reject) =>
-    mkdirp(path.dirname(filepath), mkdirpErr => {
-      if (mkdirpErr) return reject(mkdirpErr);
-
-      // ...then write the file
-      return fs.writeFile(filepath, JSON.stringify(appstate), writeErr => {
-        if (writeErr) return reject(writeErr);
-
-        return resolve(appstate);
-      });
-    }),
-  );
-}
-
-/**
  * Substitute for Object.values
  * @param {object} dict - to extract values from
  */
@@ -98,7 +77,6 @@ function objectValues(dict) {
 
 module.exports = {
   promptCredentials,
-  saveAppState,
   promptCode,
   objectValues,
   notifyTerminal,

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -1,10 +1,7 @@
-const fs = require('fs');
-const path = require('path');
-const prompt = require('prompt');
-const readline = require('readline');
-const mkdirp = require('mkdirp');
+const prompt = require("prompt");
+const readline = require("readline");
 
-const log = require('./log');
+const log = require("./log");
 
 /**
  * Adds the number of unread messages in the terminal title
@@ -13,7 +10,7 @@ const log = require('./log');
 function notifyTerminal(unreadMessagesCount) {
   const title = unreadMessagesCount
     ? `messer (${unreadMessagesCount})`
-    : 'messer';
+    : "messer";
   process.stdout.write(
     `${String.fromCharCode(27)}]0;${title}${String.fromCharCode(7)}`,
   );
@@ -24,7 +21,7 @@ function notifyTerminal(unreadMessagesCount) {
  */
 function promptCredentials() {
   log(
-    'Enter your Facebook credentials - your password will not be visible as you type it in',
+    "Enter your Facebook credentials - your password will not be visible as you type it in",
   );
   prompt.start();
 
@@ -32,11 +29,11 @@ function promptCredentials() {
     prompt.get(
       [
         {
-          name: 'email',
+          name: "email",
           required: true,
         },
         {
-          name: 'password',
+          name: "password",
           required: true,
           hidden: true,
         },
@@ -59,8 +56,8 @@ function promptCode() {
   });
 
   return new Promise(resolve => {
-    log('Enter code > ');
-    return rl.on('line', line => {
+    log("Enter code > ");
+    return rl.on("line", line => {
       resolve(line);
       rl.close();
     });

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -1,40 +1,52 @@
-const fs = require("fs")
-const path = require("path")
-const prompt = require("prompt")
-const readline = require("readline")
-const mkdirp = require("mkdirp")
+const fs = require('fs');
+const path = require('path');
+const prompt = require('prompt');
+const readline = require('readline');
+const mkdirp = require('mkdirp');
 
-const log = require("./log")
+const log = require('./log');
 
 /**
  * Adds the number of unread messages in the terminal title
  * @param {Object} unreadMessagesCount number of unread messages
  */
 function notifyTerminal(unreadMessagesCount) {
-  const title = (unreadMessagesCount) ? `messer (${unreadMessagesCount})` : "messer"
-  process.stdout.write(`${String.fromCharCode(27)}]0;${title}${String.fromCharCode(7)}`)
+  const title = unreadMessagesCount
+    ? `messer (${unreadMessagesCount})`
+    : 'messer';
+  process.stdout.write(
+    `${String.fromCharCode(27)}]0;${title}${String.fromCharCode(7)}`,
+  );
 }
 
 /**
  * Prompts the user for their username and password in the terminal
  */
 function promptCredentials() {
-  log("Enter your Facebook credentials - your password will not be visible as you type it in")
-  prompt.start()
+  log(
+    'Enter your Facebook credentials - your password will not be visible as you type it in',
+  );
+  prompt.start();
 
   return new Promise((resolve, reject) => {
-    prompt.get([{
-      name: "email",
-      required: true,
-    }, {
-      name: "password",
-      required: true,
-      hidden: true,
-    }], (err, result) => {
-      if (err) return reject(err)
-      return resolve(result)
-    })
-  })
+    prompt.get(
+      [
+        {
+          name: 'email',
+          required: true,
+        },
+        {
+          name: 'password',
+          required: true,
+          hidden: true,
+        },
+      ],
+      (err, result) => {
+        if (err) return reject(err);
+        return resolve(result);
+      },
+    );
+  });
 }
 
 /**
@@ -44,34 +56,15 @@ function promptCode() {
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
-  })
+  });
 
-  return new Promise((resolve) => {
-    log("Enter code > ")
-    return rl.on("line", (line) => {
-      resolve(line)
-      rl.close()
-    })
-  })
-}
-
-/**
- * Returns a promise resolving with the credentials to log in with.
- * First tries App State file, then prompts user for username/password
- * @return {Promise<{email: string, password: string}>}
- */
-function getCredentials(appstateFilePath) {
-  return new Promise((resolve, reject) => {
-    fs.readFile(appstateFilePath, (appStateErr, appstate) => {
-      if (!appStateErr && appstate) {
-        return resolve({ appState: JSON.parse(appstate) })
-      }
-
-      return promptCredentials()
-        .then(data => resolve(data))
-        .catch(credsErr => reject(credsErr))
-    })
-  })
+  return new Promise(resolve => {
+    log('Enter code > ');
+    return rl.on('line', line => {
+      resolve(line);
+      rl.close();
+    });
+  });
 }
 
 /**
@@ -81,16 +74,18 @@ function getCredentials(appstateFilePath) {
  * @return {Promise}
  */
 function saveAppState(appstate, filepath) {
-  return new Promise((resolve, reject) => mkdirp(path.dirname(filepath), (mkdirpErr) => {
-    if (mkdirpErr) return reject(mkdirpErr)
+  return new Promise((resolve, reject) =>
+    mkdirp(path.dirname(filepath), mkdirpErr => {
+      if (mkdirpErr) return reject(mkdirpErr);
 
-    // ...then write the file
-    return fs.writeFile(filepath, JSON.stringify(appstate), (writeErr) => {
-      if (writeErr) return reject(writeErr)
+      // ...then write the file
+      return fs.writeFile(filepath, JSON.stringify(appstate), writeErr => {
+        if (writeErr) return reject(writeErr);
 
-      return resolve(appstate)
-    })
-  }))
+        return resolve(appstate);
+      });
+    }),
+  );
 }
 
 /**
@@ -98,14 +93,13 @@ function saveAppState(appstate, filepath) {
  * @param {object} dict - to extract values from
  */
 function objectValues(dict) {
-  return Object.keys(dict).map(key => dict[key])
+  return Object.keys(dict).map(key => dict[key]);
 }
 
-
 module.exports = {
-  getCredentials,
+  promptCredentials,
   saveAppState,
   promptCode,
   objectValues,
   notifyTerminal,
-}
+};

--- a/src/util/lock.js
+++ b/src/util/lock.js
@@ -1,22 +1,22 @@
-let locked = false
-let target = ""
+let locked = false;
+let target = '';
 
 function isLocked() {
-  return locked
+  return locked;
 }
 
 function getLockedTarget() {
-  return target
+  return target;
 }
 
 function lockOn(targetUser) {
-  locked = true
-  target = targetUser
+  locked = true;
+  target = targetUser;
 }
 
 function unlock() {
-  locked = false
-  this.target = ""
+  locked = false;
+  this.target = '';
 }
 
 module.exports = {
@@ -24,4 +24,4 @@ module.exports = {
   getLockedTarget,
   lockOn,
   unlock,
-}
+};

--- a/src/util/lock.js
+++ b/src/util/lock.js
@@ -1,5 +1,5 @@
 let locked = false;
-let target = '';
+let target = "";
 
 function isLocked() {
   return locked;
@@ -16,7 +16,7 @@ function lockOn(targetUser) {
 
 function unlock() {
   locked = false;
-  this.target = '';
+  this.target = "";
 }
 
 module.exports = {

--- a/src/util/log.js
+++ b/src/util/log.js
@@ -1,4 +1,4 @@
-const chalk = require('chalk');
+const chalk = require("chalk");
 
 /**
  * Wrapper around console.log

--- a/src/util/log.js
+++ b/src/util/log.js
@@ -1,4 +1,4 @@
-const chalk = require("chalk")
+const chalk = require('chalk');
 
 /**
  * Wrapper around console.log
@@ -7,16 +7,16 @@ const chalk = require("chalk")
  */
 function log(content, color) {
   /* eslint-disable */
-  if (!content) return null
+  if (!content) return null;
   if (color) {
     if (chalk[color]) {
-      return console.log(chalk[color](content))
+      return console.log(chalk[color](content));
     }
-    return console.log(chalk.hex(color)(content))
+    return console.log(chalk.hex(color)(content));
   }
 
-  return console.log(content)
+  return console.log(content);
   /* eslint-enable */
 }
 
-module.exports = log
+module.exports = log;

--- a/test/test.js
+++ b/test/test.js
@@ -229,7 +229,7 @@ describe('Command Handlers', () => {
             type: 'message',
           },
           {
-            senderID: messer.messy.user.userID,
+            senderID: messer.messy.user.id,
             body: 'hey marn',
             type: 'message',
           },

--- a/test/test.js
+++ b/test/test.js
@@ -190,7 +190,7 @@ describe('Command Handlers', () => {
       }));
 
     it('should return something for a thread with some history', () => {
-      messerWithHistory.api.getThreadHistory = (
+      messerWithHistory.messy.api.getThreadHistory = (
         threadID,
         messageCount,
         x,
@@ -208,7 +208,7 @@ describe('Command Handlers', () => {
     });
 
     it('should handle messages where the sender is the current user', () => {
-      messerWithHistory.api.getThreadHistory = (
+      messerWithHistory.messy.api.getThreadHistory = (
         threadID,
         messageCount,
         x,
@@ -221,7 +221,7 @@ describe('Command Handlers', () => {
         return cb(null, data);
       };
 
-      messerWithHistory.api.getThreadInfo = (threadID, cb) =>
+      messerWithHistory.messy.api.getThreadInfo = (threadID, cb) =>
         cb(null, { threadID, name: 'Tom Quirk' });
 
       return messerWithHistory.processCommand('history "mark"').then(res => {
@@ -230,7 +230,7 @@ describe('Command Handlers', () => {
     });
 
     it("should return history for thread that isn't cached", () => {
-      messerWithHistory.api.getThreadHistory = (
+      messerWithHistory.messy.api.getThreadHistory = (
         threadID,
         messageCount,
         x,
@@ -242,7 +242,7 @@ describe('Command Handlers', () => {
         return cb(null, data);
       };
 
-      messerWithHistory.api.getThreadInfo = (threadID, cb) =>
+      messerWithHistory.messy.api.getThreadInfo = (threadID, cb) =>
         cb(null, { threadID, name: 'Waylon Smithers' });
 
       return messerWithHistory.processCommand('history "waylon"').then(res => {
@@ -260,7 +260,7 @@ describe('Command Handlers', () => {
       }));
 
     it('should act appropriately when [messageCount] given', () => {
-      messerWithHistory.api.getThreadHistory = (
+      messerWithHistory.messy.api.getThreadHistory = (
         threadID,
         messageCount,
         x,

--- a/test/test.js
+++ b/test/test.js
@@ -50,7 +50,7 @@ function MockMesser() {
   messer.messy.user = {
     userID: '666',
     name: 'Tom Quirk',
-    friendsList: {
+    friends: {
       'Waylon Smithers': {
         fullName: 'Waylon Smithers',
         userID: '1',
@@ -326,7 +326,7 @@ describe('Command Handlers', () => {
 
     it('should gracefully handle user with no friends', () => {
       const messerNoFriends = MockMesser();
-      messerNoFriends.messy.user.friendsList = [];
+      messerNoFriends.messy.user.friends = [];
 
       return messerNoFriends.processCommand('contacts').then(res => {
         assert.ok(res);

--- a/test/test.js
+++ b/test/test.js
@@ -1,25 +1,25 @@
-const assert = require("assert")
-const fs = require("fs")
-const path = require("path")
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
 
-const commandTypes = require("../src/commands/command-types")
-const Messer = require("../src/messer")
+const commandTypes = require('../src/commands/command-types');
+const Messer = require('../src/messer');
 
 const mockSettings = {
-  APPSTATE_FILE_PATH: path.resolve(__dirname, "tmp/appstate.json"),
-}
+  APPSTATE_FILE_PATH: path.resolve(__dirname, 'tmp/appstate.json'),
+};
 
 /**
  * Return a minimal thread as given by facebook-chat-api
  */
 function getThread() {
   return {
-    name: "Mark Zuckerberg",
-    threadID: "111",
-    color: "#000000",
+    name: 'Mark Zuckerberg',
+    threadID: '111',
+    color: '#000000',
     unreadCount: 0,
-    lastMessageTimestamp: "123456789",
-  }
+    lastMessageTimestamp: '123456789',
+  };
 }
 
 /**
@@ -28,315 +28,348 @@ function getThread() {
 function MockApi() {
   return {
     getThreadHistory(threadID, messageCount, x, cb) {
-      const data = []
-      return cb(null, data)
+      const data = [];
+      return cb(null, data);
     },
     sendMessage(message, threadID, cb) {
-      return cb(null)
+      return cb(null);
     },
-  }
+  };
 }
 
 /**
  * Factory to mock an instance of Messer
  */
 function MockMesser() {
-  const messer = new Messer()
+  const messer = new Messer();
 
-  messer.api = MockApi()
-  messer.cacheThread(getThread())
-  messer.user = {
-    userID: "666",
-    name: "Tom Quirk",
+  messer.messy.api = MockApi();
+  messer.cacheThread(getThread());
+  messer.messy.user = {
+    userID: '666',
+    name: 'Tom Quirk',
     friendsList: {
-      "Waylon Smithers": {
-        fullName: "Waylon Smithers",
-        userID: "1",
+      'Waylon Smithers': {
+        fullName: 'Waylon Smithers',
+        userID: '1',
       },
-      "Keniff Kaniff": {
-        fullName: "Keniff Kaniff",
-        userID: "2",
+      'Keniff Kaniff': {
+        fullName: 'Keniff Kaniff',
+        userID: '2',
       },
     },
-  }
+  };
 
-  return messer
+  return messer;
 }
 
 /**
  * Test Messer-related functionality
  */
-describe("Messer", () => {
+describe('Messer', () => {
   /**
    * Test cacheThread
    */
-  describe("#cacheThread(thread)", () => {
-    const messer = new Messer()
-    const thread = getThread()
+  describe('#cacheThread(thread)', () => {
+    const messer = new Messer();
+    const thread = getThread();
 
-    it("should populate threadCache as expected", () => {
-      messer.cacheThread(thread)
-      assert.deepEqual(thread, messer.threadCache[thread.threadID])
-    })
+    it('should populate threadCache as expected', () => {
+      messer.cacheThread(thread);
+      assert.deepEqual(thread, messer.threadCache[thread.threadID]);
+    });
 
-    it("should populate threadNameToIdMap as expected", () => {
-      messer.cacheThread(thread)
-      assert.equal(thread.threadID, messer.threadNameToIdMap[thread.name])
-    })
-  })
+    it('should populate threadNameToIdMap as expected', () => {
+      messer.cacheThread(thread);
+      assert.equal(thread.threadID, messer.threadNameToIdMap[thread.name]);
+    });
+  });
 
   /**
    * Test getThreadByName
    */
-  describe("#getThreadByName(name)", () => {
-    const messer = new Messer()
-    const thread = getThread()
+  describe('#getThreadByName(name)', () => {
+    const messer = new Messer();
+    const thread = getThread();
 
-    messer.cacheThread(thread)
+    messer.cacheThread(thread);
 
-    it("should retrieve thread by exact name", () => messer.getThreadByName(thread.name)
-      .then(res => assert.deepEqual(res, thread)))
+    it('should retrieve thread by exact name', () =>
+      messer
+        .getThreadByName(thread.name)
+        .then(res => assert.deepEqual(res, thread)));
 
-    it("should retrieve thread by fuzzy name", () => messer.getThreadByName("mark")
-      .then(res => assert.deepEqual(res, thread)))
+    it('should retrieve thread by fuzzy name', () =>
+      messer
+        .getThreadByName('mark')
+        .then(res => assert.deepEqual(res, thread)));
 
-    it("should fail to retrieve thread by name that is not cached", () => messer.getThreadByName("bill")
-      .catch(e => assert(e != null)))
-  })
+    it('should fail to retrieve thread by name that is not cached', () =>
+      messer.getThreadByName('bill').catch(e => assert(e != null)));
+  });
 
   /**
    * Test processCommand
    */
-  describe("#processCommand(command)", () => {
-    const messer = MockMesser()
+  describe('#processCommand(command)', () => {
+    const messer = MockMesser();
 
-    it("should process and handle a valid command", () => messer.processCommand("message \"waylon\" hey dude").then(res => assert.ok(res)))
-  })
-})
+    it('should process and handle a valid command', () =>
+      messer
+        .processCommand('message "waylon" hey dude')
+        .then(res => assert.ok(res)));
+  });
+});
 
 /**
  * Test the command handlers
  */
-describe("Command Handlers", () => {
-  const messer = MockMesser()
+describe('Command Handlers', () => {
+  const messer = MockMesser();
 
   /**
    * Test the "message" command
    */
   describe(`#${commandTypes.MESSAGE.command}`, () => {
-    it("should send message to valid threadname", () => messer.processCommand("message \"waylon\" hey dude")
-      .then((res) => {
-        assert.ok(res)
-      }))
+    it('should send message to valid threadname', () =>
+      messer.processCommand('message "waylon" hey dude').then(res => {
+        assert.ok(res);
+      }));
 
-    it("should send message to valid threadname using abbreviated command", () => messer.processCommand("m \"waylon\" hey dude")
-      .then((res) => {
-        assert.ok(res)
-      }))
+    it('should send message to valid threadname using abbreviated command', () =>
+      messer.processCommand('m "waylon" hey dude').then(res => {
+        assert.ok(res);
+      }));
 
-    it("should send message to valid thread that isn't a friend", () => messer.processCommand("message \"mark\" hey dude")
-      .then((res) => {
-        assert.ok(res)
-      }))
+    it("should send message to valid thread that isn't a friend", () =>
+      messer.processCommand('message "mark" hey dude').then(res => {
+        assert.ok(res);
+      }));
 
-    it("should fail to send message to invalid threadname", () => messer.processCommand("m \"rick\" hey dude")
-      .catch((err) => {
-        assert.equal(err, "Error: User 'rick' could not be found in your friends list!")
-      }))
-  })
+    it('should fail to send message to invalid threadname', () =>
+      messer.processCommand('m "rick" hey dude').catch(err => {
+        assert.equal(
+          err,
+          "Error: User 'rick' could not be found in your friends list!",
+        );
+      }));
+  });
 
   /**
    * Test the "reply" command
    */
   describe(`#${commandTypes.REPLY.command}`, () => {
-    const messerCanReply = MockMesser()
-    messerCanReply.lastThread = getThread()
+    const messerCanReply = MockMesser();
+    messerCanReply.lastThread = getThread();
 
-    it("should fail if no message has been recieved", () => messer.processCommand("reply hey dude")
-      .catch((err) => {
-        assert.ok(err)
-      }))
+    it('should fail if no message has been recieved', () =>
+      messer.processCommand('reply hey dude').catch(err => {
+        assert.ok(err);
+      }));
 
-    it("should reply", () => messerCanReply.processCommand("reply yea i agree")
-      .then(() => {
-        assert.ok(true)
-      }))
+    it('should reply', () =>
+      messerCanReply.processCommand('reply yea i agree').then(() => {
+        assert.ok(true);
+      }));
 
-    it("should reply using abbreviated command", () => messerCanReply.processCommand("r yea i agree")
-      .then(() => {
-        assert.ok(true)
-      }))
-  })
-
+    it('should reply using abbreviated command', () =>
+      messerCanReply.processCommand('r yea i agree').then(() => {
+        assert.ok(true);
+      }));
+  });
 
   /**
    * Test the "history" command
    */
   describe(`#${commandTypes.HISTORY.command}`, () => {
-    const messerWithHistory = MockMesser()
+    const messerWithHistory = MockMesser();
 
-    it("should gracefully fail if no thread found", () => messer.processCommand("history \"bill\"")
-      .catch((err) => {
-        assert.ok(err)
-      }))
+    it('should gracefully fail if no thread found', () =>
+      messer.processCommand('history "bill"').catch(err => {
+        assert.ok(err);
+      }));
 
-    it("should return something for a thread with some history", () => {
-      messerWithHistory.api.getThreadHistory = (threadID, messageCount, x, cb) => {
-        const data = [{ senderID: "111", body: "hey dude", type: "message" }]
-        return cb(null, data)
-      }
-      return messerWithHistory.processCommand("history \"mark\"")
-        .then((res) => {
-          assert.ok(res.trim().split("\n"))
-          assert.ok(!res.includes("undefined"))
-          assert.ok(!res.includes("null"))
-          assert.ok(res.includes("Mark"))
-        })
-    })
+    it('should return something for a thread with some history', () => {
+      messerWithHistory.api.getThreadHistory = (
+        threadID,
+        messageCount,
+        x,
+        cb,
+      ) => {
+        const data = [{ senderID: '111', body: 'hey dude', type: 'message' }];
+        return cb(null, data);
+      };
+      return messerWithHistory.processCommand('history "mark"').then(res => {
+        assert.ok(res.trim().split('\n'));
+        assert.ok(!res.includes('undefined'));
+        assert.ok(!res.includes('null'));
+        assert.ok(res.includes('Mark'));
+      });
+    });
 
-    it("should handle messages where the sender is the current user", () => {
-      messerWithHistory.api.getThreadHistory = (threadID, messageCount, x, cb) => {
+    it('should handle messages where the sender is the current user', () => {
+      messerWithHistory.api.getThreadHistory = (
+        threadID,
+        messageCount,
+        x,
+        cb,
+      ) => {
         const data = [
-          { senderID: "111", body: "hey dude", type: "message" },
-          { senderID: messer.user.userID, body: "hey marn", type: "message" },
-        ]
-        return cb(null, data)
-      }
+          { senderID: '111', body: 'hey dude', type: 'message' },
+          { senderID: messer.user.userID, body: 'hey marn', type: 'message' },
+        ];
+        return cb(null, data);
+      };
 
-      messerWithHistory.api.getThreadInfo = (threadID, cb) => cb(null, { threadID, name: "Tom Quirk" })
+      messerWithHistory.api.getThreadInfo = (threadID, cb) =>
+        cb(null, { threadID, name: 'Tom Quirk' });
 
-      return messerWithHistory.processCommand("history \"mark\"")
-        .then((res) => {
-          assert.ok(res.includes(messer.user.name))
-        })
-    })
+      return messerWithHistory.processCommand('history "mark"').then(res => {
+        assert.ok(res.includes(messer.user.name));
+      });
+    });
 
     it("should return history for thread that isn't cached", () => {
-      messerWithHistory.api.getThreadHistory = (threadID, messageCount, x, cb) => {
-        const data = [{ senderID: "1", body: "hey im waylon", type: "message" }]
-        return cb(null, data)
-      }
-
-      messerWithHistory.api.getThreadInfo = (threadID, cb) => cb(null, { threadID, name: "Waylon Smithers" })
-
-      return messerWithHistory.processCommand("history \"waylon\"")
-        .then((res) => {
-          assert.ok(res.trim().split("\n"))
-          assert.ok(!res.includes("undefined"))
-          assert.ok(!res.includes("null"))
-          assert.ok(res.includes("Waylon"))
-        })
-    })
-
-    it("should return truthy value when no history exists in thread", () => messer.processCommand("history \"waylon\"")
-      .then((res) => {
-        assert.ok(res)
-        assert.ok(!res.includes("waylon"))
-      }))
-
-    it("should act appropriately when [messageCount] given", () => {
-      messerWithHistory.api.getThreadHistory = (threadID, messageCount, x, cb) => {
+      messerWithHistory.api.getThreadHistory = (
+        threadID,
+        messageCount,
+        x,
+        cb,
+      ) => {
         const data = [
-          { senderID: "111", body: "hey dude", type: "message" },
-          { senderID: "111", body: "hey dude", type: "message" },
-          { senderID: "111", body: "hey dude", type: "message" },
-          { senderID: "111", body: "hey dude", type: "message" },
-        ].slice(0, messageCount)
-        return cb(null, data)
-      }
-      return messerWithHistory.processCommand("history \"mark\" 2")
-        .then((res) => {
-          assert.equal(res.trim().split("\n").length, 2)
-          assert.ok(!res.includes("undefined"))
-          assert.ok(!res.includes("null"))
-          assert.ok(res.includes("Mark"))
-        })
-    })
-  })
+          { senderID: '1', body: 'hey im waylon', type: 'message' },
+        ];
+        return cb(null, data);
+      };
+
+      messerWithHistory.api.getThreadInfo = (threadID, cb) =>
+        cb(null, { threadID, name: 'Waylon Smithers' });
+
+      return messerWithHistory.processCommand('history "waylon"').then(res => {
+        assert.ok(res.trim().split('\n'));
+        assert.ok(!res.includes('undefined'));
+        assert.ok(!res.includes('null'));
+        assert.ok(res.includes('Waylon'));
+      });
+    });
+
+    it('should return truthy value when no history exists in thread', () =>
+      messer.processCommand('history "waylon"').then(res => {
+        assert.ok(res);
+        assert.ok(!res.includes('waylon'));
+      }));
+
+    it('should act appropriately when [messageCount] given', () => {
+      messerWithHistory.api.getThreadHistory = (
+        threadID,
+        messageCount,
+        x,
+        cb,
+      ) => {
+        const data = [
+          { senderID: '111', body: 'hey dude', type: 'message' },
+          { senderID: '111', body: 'hey dude', type: 'message' },
+          { senderID: '111', body: 'hey dude', type: 'message' },
+          { senderID: '111', body: 'hey dude', type: 'message' },
+        ].slice(0, messageCount);
+        return cb(null, data);
+      };
+      return messerWithHistory.processCommand('history "mark" 2').then(res => {
+        assert.equal(res.trim().split('\n').length, 2);
+        assert.ok(!res.includes('undefined'));
+        assert.ok(!res.includes('null'));
+        assert.ok(res.includes('Mark'));
+      });
+    });
+  });
 
   /**
    * Test the "contacts" command
    */
   describe(`#${commandTypes.CONTACTS.command}`, () => {
-    it("should return list of friends sep. by newline", () => messer.processCommand(commandTypes.CONTACTS.command)
-      .then((res) => {
-        assert.equal(res, "Keniff Kaniff\nWaylon Smithers\n")
-      }))
+    it('should return list of friends sep. by newline', () =>
+      messer.processCommand(commandTypes.CONTACTS.command).then(res => {
+        assert.equal(res, 'Keniff Kaniff\nWaylon Smithers\n');
+      }));
 
-    it("should gracefully handle user with no friends", () => {
-      const messerNoFriends = MockMesser()
-      messerNoFriends.user.friendsList = []
+    it('should gracefully handle user with no friends', () => {
+      const messerNoFriends = MockMesser();
+      messerNoFriends.user.friendsList = [];
 
-      return messerNoFriends.processCommand("contacts")
-        .then((res) => {
-          assert.ok(res)
-        })
-    })
-  })
+      return messerNoFriends.processCommand('contacts').then(res => {
+        assert.ok(res);
+      });
+    });
+  });
 
   /**
    * Test the "help" command
    */
   describe(`#${commandTypes.HELP.command}`, () => {
-    it("should return some truthy value", () => messer.processCommand(commandTypes.HELP.command)
-      .then((res) => {
-        assert.ok(res)
-      }))
-  })
+    it('should return some truthy value', () =>
+      messer.processCommand(commandTypes.HELP.command).then(res => {
+        assert.ok(res);
+      }));
+  });
 
   /**
    * Test the "logout" command
    */
   describe(`#${commandTypes.LOGOUT.command}`, () => {
-    it("should remove appstate file", () => {
-      fs.writeFile(mockSettings.APPSTATE_FILE_PATH, "{}", () => messer.processCommand(commandTypes.LOGOUT.command)
-        .then(() => {
-          assert.ok(!fs.existsSync(mockSettings.APPSTATE_FILE_PATH))
-        }))
-    })
-  })
+    it('should remove appstate file', () => {
+      fs.writeFile(mockSettings.APPSTATE_FILE_PATH, '{}', () =>
+        messer.processCommand(commandTypes.LOGOUT.command).then(() => {
+          assert.ok(!fs.existsSync(mockSettings.APPSTATE_FILE_PATH));
+        }),
+      );
+    });
+  });
 
   /**
    * Test the "lock" command
    */
   describe(`#${commandTypes.LOCK.command}`, () => {
-    it("should lock on to a valid thread name and porcess every input line as a message command", () => messer.processCommand("lock waylon")
-      .then(() => messer.processCommand("hey, dude")
-        .then((res) => {
-          assert.ok(res)
-        })))
+    it('should lock on to a valid thread name and porcess every input line as a message command', () =>
+      messer.processCommand('lock waylon').then(() =>
+        messer.processCommand('hey, dude').then(res => {
+          assert.ok(res);
+        }),
+      ));
 
-    it("should lock on to a valid thread name that is not a friend and porcess every input line as a message command", () => messer.processCommand("lock mark")
-      .then(() => messer.processCommand("hey, dude")
-        .then((res) => {
-          assert.ok(res)
-        })))
+    it('should lock on to a valid thread name that is not a friend and porcess every input line as a message command', () =>
+      messer.processCommand('lock mark').then(() =>
+        messer.processCommand('hey, dude').then(res => {
+          assert.ok(res);
+        }),
+      ));
 
-    it("should fail if no thread name is specified", () => messer.processCommand("lock")
-      .catch((err) => {
-        assert.ok(err)
-      }))
+    it('should fail if no thread name is specified', () =>
+      messer.processCommand('lock').catch(err => {
+        assert.ok(err);
+      }));
 
-    it("should fail if a non-existant thread name is specified", () => messer.processCommand("lock asd")
-      .catch((err) => {
-        assert.ok(err)
-      }))
-  })
+    it('should fail if a non-existant thread name is specified', () =>
+      messer.processCommand('lock asd').catch(err => {
+        assert.ok(err);
+      }));
+  });
 
   /**
    * Test the "unlock" command
    */
   describe(`#${commandTypes.UNLOCK.command}`, () => {
-    it("should free up the input to type regular commands", () => messer.processCommand("lock waylon")
-      .then(() => messer.processCommand("unlock")
-        .then(() => messer.processCommand("m \"waylon\" hey, dude")
-          .then((res) => {
-            assert.ok(res)
-          }))))
+    it('should free up the input to type regular commands', () =>
+      messer.processCommand('lock waylon').then(() =>
+        messer.processCommand('unlock').then(() =>
+          messer.processCommand('m "waylon" hey, dude').then(res => {
+            assert.ok(res);
+          }),
+        ),
+      ));
 
-    it("should fail if no lock command was issued beforehand", () => messer.processCommand("unlock")
-      .catch((err) => {
-        assert.ok(err)
-      }))
-  })
-})
+    it('should fail if no lock command was issued beforehand', () =>
+      messer.processCommand('unlock').catch(err => {
+        assert.ok(err);
+      }));
+  });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -48,18 +48,18 @@ function MockMesser() {
   messer.messy.api = MockApi();
   messer.cacheThread(getMockThread());
   messer.messy.user = {
-    userID: '666',
+    id: '666',
     name: 'Tom Quirk',
-    friends: {
-      'Waylon Smithers': {
+    friends: [
+      {
         fullName: 'Waylon Smithers',
         userID: '1',
       },
-      'Keniff Kaniff': {
+      {
         fullName: 'Keniff Kaniff',
         userID: '2',
       },
-    },
+    ],
   };
 
   return messer;
@@ -119,7 +119,12 @@ describe('Messer', () => {
     it('should process and handle a valid command', () =>
       messer
         .processCommand('message "waylon" hey dude')
-        .then(res => assert.ok(res)));
+        .then(res => {
+          assert.ok(res);
+        })
+        .catch(err => {
+          console.log(err);
+        }));
   });
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,20 +1,20 @@
-const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
 
-const commandTypes = require('../src/commands/command-types');
-const Messer = require('../src/messer');
+const commandTypes = require("../src/commands/command-types");
+const Messer = require("../src/messer");
 
 const mockSettings = {
-  APPSTATE_FILE_PATH: path.resolve(__dirname, 'tmp/appstate.json'),
+  APPSTATE_FILE_PATH: path.resolve(__dirname, "tmp/appstate.json"),
 };
 
 const DEFAULT_MOCK_THREAD = {
-  name: 'Mark Zuckerberg',
-  threadID: '111',
-  color: '#000000',
+  name: "Mark Zuckerberg",
+  threadID: "111",
+  color: "#000000",
   unreadCount: 0,
-  lastMessageTimestamp: '123456789',
+  lastMessageTimestamp: "123456789",
 };
 
 /**
@@ -48,16 +48,16 @@ function MockMesser() {
   messer.messen.api = MockApi();
   messer.cacheThread(getMockThread());
   messer.messen.user = {
-    id: '666',
-    name: 'Tom Quirk',
+    id: "666",
+    name: "Tom Quirk",
     friends: [
       {
-        fullName: 'Waylon Smithers',
-        userID: '1',
+        fullName: "Waylon Smithers",
+        userID: "1",
       },
       {
-        fullName: 'Keniff Kaniff',
-        userID: '2',
+        fullName: "Keniff Kaniff",
+        userID: "2",
       },
     ],
   };
@@ -68,20 +68,20 @@ function MockMesser() {
 /**
  * Test Messer-related functionality
  */
-describe('Messer', () => {
+describe("Messer", () => {
   /**
    * Test cacheThread
    */
-  describe('#cacheThread(thread)', () => {
+  describe("#cacheThread(thread)", () => {
     const messer = new Messer();
     const thread = getMockThread();
 
-    it('should populate threadCache as expected', () => {
+    it("should populate threadCache as expected", () => {
       messer.cacheThread(thread);
       assert.deepEqual(thread, messer.threadCache[thread.threadID]);
     });
 
-    it('should populate threadNameToIdMap as expected', () => {
+    it("should populate threadNameToIdMap as expected", () => {
       messer.cacheThread(thread);
       assert.equal(thread.threadID, messer.threadNameToIdMap[thread.name]);
     });
@@ -90,33 +90,33 @@ describe('Messer', () => {
   /**
    * Test getThreadByName
    */
-  describe('#getThreadByName(name)', () => {
+  describe("#getThreadByName(name)", () => {
     const messer = new Messer();
     const thread = getMockThread();
 
     messer.cacheThread(thread);
 
-    it('should retrieve thread by exact name', () =>
+    it("should retrieve thread by exact name", () =>
       messer
         .getThreadByName(thread.name)
         .then(res => assert.deepEqual(res, thread)));
 
-    it('should retrieve thread by fuzzy name', () =>
+    it("should retrieve thread by fuzzy name", () =>
       messer
-        .getThreadByName('mark')
+        .getThreadByName("mark")
         .then(res => assert.deepEqual(res, thread)));
 
-    it('should fail to retrieve thread by name that is not cached', () =>
-      messer.getThreadByName('bill').catch(e => assert(e != null)));
+    it("should fail to retrieve thread by name that is not cached", () =>
+      messer.getThreadByName("bill").catch(e => assert(e != null)));
   });
 
   /**
    * Test processCommand
    */
-  describe('#processCommand(command)', () => {
+  describe("#processCommand(command)", () => {
     const messer = MockMesser();
 
-    it('should process and handle a valid command', () =>
+    it("should process and handle a valid command", () =>
       messer.processCommand('message "waylon" hey dude').then(res => {
         assert.ok(res);
       }));
@@ -126,19 +126,19 @@ describe('Messer', () => {
 /**
  * Test the command handlers
  */
-describe('Command Handlers', () => {
+describe("Command Handlers", () => {
   const messer = MockMesser();
 
   /**
    * Test the "message" command
    */
   describe(`#${commandTypes.MESSAGE.command}`, () => {
-    it('should send message to valid threadname', () =>
+    it("should send message to valid threadname", () =>
       messer.processCommand('message "waylon" hey dude').then(res => {
         assert.ok(res);
       }));
 
-    it('should send message to valid threadname using abbreviated command', () =>
+    it("should send message to valid threadname using abbreviated command", () =>
       messer.processCommand('m "waylon" hey dude').then(res => {
         assert.ok(res);
       }));
@@ -148,7 +148,7 @@ describe('Command Handlers', () => {
         assert.ok(res);
       }));
 
-    it('should fail to send message to invalid threadname', () =>
+    it("should fail to send message to invalid threadname", () =>
       messer.processCommand('m "rick" hey dude').catch(err => {
         assert.equal(
           err,
@@ -164,18 +164,18 @@ describe('Command Handlers', () => {
     const messerCanReply = MockMesser();
     messerCanReply.lastThread = getMockThread();
 
-    it('should fail if no message has been recieved', () =>
-      messer.processCommand('reply hey dude').catch(err => {
+    it("should fail if no message has been recieved", () =>
+      messer.processCommand("reply hey dude").catch(err => {
         assert.ok(err);
       }));
 
-    it('should reply', () =>
-      messerCanReply.processCommand('reply yea i agree').then(() => {
+    it("should reply", () =>
+      messerCanReply.processCommand("reply yea i agree").then(() => {
         assert.ok(true);
       }));
 
-    it('should reply using abbreviated command', () =>
-      messerCanReply.processCommand('r yea i agree').then(() => {
+    it("should reply using abbreviated command", () =>
+      messerCanReply.processCommand("r yea i agree").then(() => {
         assert.ok(true);
       }));
   });
@@ -186,12 +186,12 @@ describe('Command Handlers', () => {
   describe(`#${commandTypes.HISTORY.command}`, () => {
     const messerWithHistory = MockMesser();
 
-    it('should gracefully fail if no thread found', () =>
+    it("should gracefully fail if no thread found", () =>
       messer.processCommand('history "bill"').catch(err => {
         assert.ok(err);
       }));
 
-    it('should return something for a thread with some history', () => {
+    it("should return something for a thread with some history", () => {
       messerWithHistory.messen.api.getThreadHistory = (
         threadID,
         messageCount,
@@ -201,21 +201,21 @@ describe('Command Handlers', () => {
         const data = [
           {
             senderID: DEFAULT_MOCK_THREAD.threadID,
-            body: 'hey dude',
-            type: 'message',
+            body: "hey dude",
+            type: "message",
           },
         ];
         return cb(null, data);
       };
       return messerWithHistory.processCommand('history "mark"').then(res => {
-        assert.ok(res.trim().split('\n'));
-        assert.ok(!res.includes('undefined'));
-        assert.ok(!res.includes('null'));
-        assert.ok(res.includes('Mark'));
+        assert.ok(res.trim().split("\n"));
+        assert.ok(!res.includes("undefined"));
+        assert.ok(!res.includes("null"));
+        assert.ok(res.includes("Mark"));
       });
     });
 
-    it('should handle messages where the sender is the current user', () => {
+    it("should handle messages where the sender is the current user", () => {
       messerWithHistory.messen.api.getThreadHistory = (
         threadID,
         messageCount,
@@ -225,20 +225,20 @@ describe('Command Handlers', () => {
         const data = [
           {
             senderID: DEFAULT_MOCK_THREAD.threadID,
-            body: 'hey dude',
-            type: 'message',
+            body: "hey dude",
+            type: "message",
           },
           {
             senderID: messer.messen.user.id,
-            body: 'hey marn',
-            type: 'message',
+            body: "hey marn",
+            type: "message",
           },
         ];
         return cb(null, data);
       };
 
       messerWithHistory.messen.api.getThreadInfo = (threadID, cb) =>
-        cb(null, { threadID, name: 'Tom Quirk' });
+        cb(null, { threadID, name: "Tom Quirk" });
 
       return messerWithHistory.processCommand('history "mark"').then(res => {
         assert.ok(res.includes(messer.messen.user.name));
@@ -253,29 +253,29 @@ describe('Command Handlers', () => {
         cb,
       ) => {
         const data = [
-          { senderID: '1', body: 'hey im waylon', type: 'message' },
+          { senderID: "1", body: "hey im waylon", type: "message" },
         ];
         return cb(null, data);
       };
 
       messerWithHistory.messen.api.getThreadInfo = (threadID, cb) =>
-        cb(null, { threadID, name: 'Waylon Smithers' });
+        cb(null, { threadID, name: "Waylon Smithers" });
 
       return messerWithHistory.processCommand('history "waylon"').then(res => {
-        assert.ok(res.trim().split('\n'));
-        assert.ok(!res.includes('undefined'));
-        assert.ok(!res.includes('null'));
-        assert.ok(res.includes('Waylon'));
+        assert.ok(res.trim().split("\n"));
+        assert.ok(!res.includes("undefined"));
+        assert.ok(!res.includes("null"));
+        assert.ok(res.includes("Waylon"));
       });
     });
 
-    it('should return truthy value when no history exists in thread', () =>
+    it("should return truthy value when no history exists in thread", () =>
       messer.processCommand('history "waylon"').then(res => {
         assert.ok(res);
-        assert.ok(!res.includes('waylon'));
+        assert.ok(!res.includes("waylon"));
       }));
 
-    it('should act appropriately when [messageCount] given', () => {
+    it("should act appropriately when [messageCount] given", () => {
       messerWithHistory.messen.api.getThreadHistory = (
         threadID,
         messageCount,
@@ -285,32 +285,32 @@ describe('Command Handlers', () => {
         const data = [
           {
             senderID: DEFAULT_MOCK_THREAD.threadID,
-            body: 'hey dude',
-            type: 'message',
+            body: "hey dude",
+            type: "message",
           },
           {
             senderID: DEFAULT_MOCK_THREAD.threadID,
-            body: 'hey dude',
-            type: 'message',
+            body: "hey dude",
+            type: "message",
           },
           {
             senderID: DEFAULT_MOCK_THREAD.threadID,
-            body: 'hey dude',
-            type: 'message',
+            body: "hey dude",
+            type: "message",
           },
           {
             senderID: DEFAULT_MOCK_THREAD.threadID,
-            body: 'hey dude',
-            type: 'message',
+            body: "hey dude",
+            type: "message",
           },
         ].slice(0, messageCount);
         return cb(null, data);
       };
       return messerWithHistory.processCommand('history "mark" 2').then(res => {
-        assert.equal(res.trim().split('\n').length, 2);
-        assert.ok(!res.includes('undefined'));
-        assert.ok(!res.includes('null'));
-        assert.ok(res.includes('Mark'));
+        assert.equal(res.trim().split("\n").length, 2);
+        assert.ok(!res.includes("undefined"));
+        assert.ok(!res.includes("null"));
+        assert.ok(res.includes("Mark"));
       });
     });
   });
@@ -319,16 +319,16 @@ describe('Command Handlers', () => {
    * Test the "contacts" command
    */
   describe(`#${commandTypes.CONTACTS.command}`, () => {
-    it('should return list of friends sep. by newline', () =>
+    it("should return list of friends sep. by newline", () =>
       messer.processCommand(commandTypes.CONTACTS.command).then(res => {
-        assert.equal(res, 'Keniff Kaniff\nWaylon Smithers\n');
+        assert.equal(res, "Keniff Kaniff\nWaylon Smithers\n");
       }));
 
-    it('should gracefully handle user with no friends', () => {
+    it("should gracefully handle user with no friends", () => {
       const messerNoFriends = MockMesser();
       messerNoFriends.messen.user.friends = [];
 
-      return messerNoFriends.processCommand('contacts').then(res => {
+      return messerNoFriends.processCommand("contacts").then(res => {
         assert.ok(res);
       });
     });
@@ -338,7 +338,7 @@ describe('Command Handlers', () => {
    * Test the "help" command
    */
   describe(`#${commandTypes.HELP.command}`, () => {
-    it('should return some truthy value', () =>
+    it("should return some truthy value", () =>
       messer.processCommand(commandTypes.HELP.command).then(res => {
         assert.ok(res);
       }));
@@ -348,8 +348,8 @@ describe('Command Handlers', () => {
    * Test the "logout" command
    */
   describe(`#${commandTypes.LOGOUT.command}`, () => {
-    it('should remove appstate file', () => {
-      fs.writeFile(mockSettings.APPSTATE_FILE_PATH, '{}', () =>
+    it("should remove appstate file", () => {
+      fs.writeFile(mockSettings.APPSTATE_FILE_PATH, "{}", () =>
         messer.processCommand(commandTypes.LOGOUT.command).then(() => {
           assert.ok(!fs.existsSync(mockSettings.APPSTATE_FILE_PATH));
         }),
@@ -361,27 +361,27 @@ describe('Command Handlers', () => {
    * Test the "lock" command
    */
   describe(`#${commandTypes.LOCK.command}`, () => {
-    it('should lock on to a valid thread name and porcess every input line as a message command', () =>
-      messer.processCommand('lock waylon').then(() =>
-        messer.processCommand('hey, dude').then(res => {
+    it("should lock on to a valid thread name and porcess every input line as a message command", () =>
+      messer.processCommand("lock waylon").then(() =>
+        messer.processCommand("hey, dude").then(res => {
           assert.ok(res);
         }),
       ));
 
-    it('should lock on to a valid thread name that is not a friend and porcess every input line as a message command', () =>
-      messer.processCommand('lock mark').then(() =>
-        messer.processCommand('hey, dude').then(res => {
+    it("should lock on to a valid thread name that is not a friend and porcess every input line as a message command", () =>
+      messer.processCommand("lock mark").then(() =>
+        messer.processCommand("hey, dude").then(res => {
           assert.ok(res);
         }),
       ));
 
-    it('should fail if no thread name is specified', () =>
-      messer.processCommand('lock').catch(err => {
+    it("should fail if no thread name is specified", () =>
+      messer.processCommand("lock").catch(err => {
         assert.ok(err);
       }));
 
-    it('should fail if a non-existant thread name is specified', () =>
-      messer.processCommand('lock asd').catch(err => {
+    it("should fail if a non-existant thread name is specified", () =>
+      messer.processCommand("lock asd").catch(err => {
         assert.ok(err);
       }));
   });
@@ -390,17 +390,17 @@ describe('Command Handlers', () => {
    * Test the "unlock" command
    */
   describe(`#${commandTypes.UNLOCK.command}`, () => {
-    it('should free up the input to type regular commands', () =>
-      messer.processCommand('lock waylon').then(() =>
-        messer.processCommand('unlock').then(() =>
+    it("should free up the input to type regular commands", () =>
+      messer.processCommand("lock waylon").then(() =>
+        messer.processCommand("unlock").then(() =>
           messer.processCommand('m "waylon" hey, dude').then(res => {
             assert.ok(res);
           }),
         ),
       ));
 
-    it('should fail if no lock command was issued beforehand', () =>
-      messer.processCommand('unlock').catch(err => {
+    it("should fail if no lock command was issued beforehand", () =>
+      messer.processCommand("unlock").catch(err => {
         assert.ok(err);
       }));
   });


### PR DESCRIPTION
Messen is a new lightweight framework I've created that aims to make it easy to create Facebook messenger apps in Node.js on top of `facebook-chat-api`. Essentially all it does for now is handle login and allows user to define event handlers for various events, like messages, 2fa prompts etc.

This means I've stripped out a bunch of stuff in Messer.

I also added prettier, hence the big diffs...