### PR TITLE
Change terminal notification to unique thread ids

### DIFF
--- a/src/event-handlers/message.js
+++ b/src/event-handlers/message.js
@@ -57,7 +57,7 @@ module.exports = messer => {
       messer.state.threads.unreadThreadIds.push(thread.threadID);
       messer.state.threads.lastThreadId = ev.threadID;
 
-      notifyTerminal(messer.state.threads.unreadThreadIds.length); // Terminal notification in title
+      notifyTerminal(new Set(messer.state.threads.unreadThreadIds).size); // Terminal notification in title
       process.stderr.write("\x07"); // Terminal notification
     },
   };


### PR DESCRIPTION
Terminal notifications should now display the number of friends that have messaged the user, not the total number of messages. Fixes #129 