### PR TITLE
Update messen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "messer",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -181,9 +181,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -1889,9 +1889,9 @@
       }
     },
     "messen": {
-      "version": "1.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/messen/-/messen-1.0.0-beta.9.tgz",
-      "integrity": "sha512-o2h7kBJzSkr5N29DIlPAABW9+QWic0RR2jWlVnPqZZXOfgL9Q/HGwyGF6fHIXc17IPCg68Tiz7o998uIPnDzow==",
+      "version": "1.0.0-beta.10",
+      "resolved": "https://registry.npmjs.org/messen/-/messen-1.0.0-beta.10.tgz",
+      "integrity": "sha512-xtcIptdFNYTObmy5cDCRUbFBSqA0zxY2UqeuMVAoefOLrsS0BltdYgKEHuJA/u7cPunYE9QtKieuqayO4weJZg==",
       "requires": {
         "dotenv": "^6.2.0",
         "facebook-chat-api": "github:Schmavery/facebook-chat-api",
@@ -2592,9 +2592,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safer-buffer": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "chalk": "^2.4.2",
-    "messen": "1.0.0-beta.9",
+    "messen": "1.0.0-beta.10",
     "minimist": "^1.2.5",
     "prompt": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messer",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Command-line messaging for Facebook Messenger",
   "keywords": [
     "facebook",

--- a/src/messer/index.js
+++ b/src/messer/index.js
@@ -146,7 +146,7 @@ Messer.prototype.start = function start(interactive = true, rawCommand) {
       });
     })
     .catch(err => {
-      console.log(err.message);
+      console.log(err.message || err);
       // recur
       // return this.start(interactive, rawCommand);
     });


### PR DESCRIPTION
Use beta.10 version of messen to fix incoming messages bug (to use `listenMqtt`)

Fixes #137