### PR TITLE
Allow special characters in lock mode

### DIFF
--- a/src/messer/index.js
+++ b/src/messer/index.js
@@ -156,10 +156,11 @@ Messer.prototype.processCommand = function processCommand(rawCommand) {
   // ignore if rawCommand is only spaces
   if (rawCommand.trim().length === 0) return Promise.resolve();
 
-  const argv = rawCommand.match(/([A-z]+).*/);
+  let argv = rawCommand.match(/([A-z]+).*/);
 
   // if we're in a lock, hack args to use the `message` command
   if (this.lock.isLocked()) {
+    argv = rawCommand.match(/.*/);
     if (rawCommand === "--unlock\n") {
       argv[1] = "--unlock";
       rawCommand = "--unlock";

--- a/test/test.js
+++ b/test/test.js
@@ -328,6 +328,28 @@ describe("Messer", function() {
           });
       });
 
+      it("should allow special characters to be used in the message body", async function() {
+        await messer
+          .processCommand('lock "waylon"')
+          .then(() => {
+            return messer.processCommand("?!!${}\"");
+          })
+          .then(res => {
+            assert.ok(res)
+          })
+      })
+
+      it("should allow foreign languages to be used in the message body", async function() {
+        await messer
+          .processCommand('lock "waylon"')
+          .then(() => {
+            return messer.processCommand("大家好");
+          })
+          .then(res => {
+            assert.ok(res)
+          })
+      })
+
       it("should fail if no thread name is specified", async function() {
         await messer.processCommand("lock").catch(err => {
           assert.ok(err);


### PR DESCRIPTION
Regex now allows matching with any first character when user is in lock mode. Fixes #135 